### PR TITLE
#164046240 Integrating Travis CI to Authors Haven 

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,2 @@
+service_name: travis-pro
+repo_token: bZWUyvMiRymHxVnOIP20PUAC2lt6vx7iZ

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+language: python
+python:
+  - "3.6"
+  
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+  - pip install coveralls
+  - pip install coverage
+
+# command to run tests
+script: 
+  - coverage run --source=authors.apps ./manage.py test --settings=authors.settings.test
+  - coverage
+    
+after_success:
+  - coverallslanguage: python
+  - coveralls

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![Build Status](https://travis-ci.org/andela/ah-legion-backend.svg?branch=master)](https://travis-ci.org/andela/ah-legion-backend.svg?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/github/andela/ah-legion-backend/badge.svg?branch=develop)](https://coveralls.io/github/andela/ah-legion-backend?branch=develop)
+
 Authors Haven - A Social platform for the creative at heart.
 =======
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
+coverage==4.5.2
+coveralls==1.6.0
 dj-database-url==0.5.0
 Django==2.1.7
 django-cors-middleware==1.3.1
@@ -8,3 +10,4 @@ PyJWT==1.4.2
 python-decouple==3.1
 pytz==2018.9
 six==1.10.0
+


### PR DESCRIPTION
**What does this PR do?**
This PR configures Travis CI and adds coverage and build badge to the README.md

**Description of task to be completed?**
- configure Travis CI
- configure Coveralls
- add coverage and build badges to README.md

**How should	this be manually tested?**
- [Travis CI](https://travis-ci.org/andela/ah-legion-backend/builds)

**Any background context you may want to provide?**
- Travis CI is a tool used to check builds and test of projects hosted in github. It also provides continous intergration of the project.

**What are the relevant pivotal tracer stories?**
- [#164046240](https://www.pivotaltracker.com/n/projects/2313280)
- [#164046243](https://www.pivotaltracker.com/n/projects/2313280)
