### PR TITLE
#164046241 Configure legion-backend to run on Postgresql

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,8 @@ ENV/
 
 # SQLite3
 db.sqlite3
+
+migrations/
+
+.DS_Store
+.vscode/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,34 @@ Authors Haven - A Social platform for the creative at heart.
 Create a community of like minded authors to foster inspiration and innovation
 by leveraging the modern web.
 
----
+## Running the app.
+Authors Haven app can by:
+### STEP 1:
+    Git clone this repository: `git clone https://github.com/andela/ah-legion-backend.git`
+
+### STEP 2: 
+    Change your working directory to the app's root. `cd ah-legion-backend`
+
+### STEP 3:
+    Create a virtual environment and activate it.
+    Install all the requirements by running `pip install -r requirements.txt`
+    Create an environment file with environment variables in the following format:
+  
+      SECRET_KEY=supersecretkey
+      DEBUG=True
+      DB_NAME=yourdbname
+      DB_USER=yourname
+      DB_PASSWORD=yourstrongpassword
+      DB_HOST=127.0.0.1
+
+### STEP 4:
+    Run the app according to the environment you need:
+
+   #### Development environment:
+    `python manage.py runserver --settings=authors.settings.dev`
+
+   #### Testing environment:
+    `python manage.py test --settings=authors.settings.test`
 
 ## API Spec
 The preferred JSON object to be returned by the API should be structured as follows:
@@ -390,7 +417,3 @@ No additional parameters required
 ### Get Tags
 
 `GET /api/tags`
-
-
-
-

--- a/authors/settings/base.py
+++ b/authors/settings/base.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/1.11/ref/settings/
 """
 
 import os
+from decouple import config, Csv
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -74,18 +75,6 @@ TEMPLATES = [
 
 WSGI_APPLICATION = 'authors.wsgi.application'
 
-# Database
-# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
-
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
-}
-
-# Password validation
-# https://docs.djangoproject.com/en/1.11/ref/settings/#auth-password-validators
 
 AUTH_PASSWORD_VALIDATORS = [
     {

--- a/authors/settings/dev.py
+++ b/authors/settings/dev.py
@@ -1,0 +1,19 @@
+import os
+from authors.settings.base import *
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+# Database
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': config('DB_NAME', default = 'legion_backend'),
+        'USER': config('DB_USER', default = 'legion'),
+        'PASSWORD': config('DB_PASSWORD', default = '&L3g10n'),
+        'HOST': config('DB_HOST'),
+        'PORT': '',
+    }
+}

--- a/authors/settings/prod.py
+++ b/authors/settings/prod.py
@@ -1,0 +1,14 @@
+import os
+import dj_database_url
+from authors.settings.base import *
+
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = False
+
+
+DATABASES = {
+    'default': dj_database_url.config(
+        default=config('DATABASE_URL')
+    )
+}

--- a/authors/settings/staging.py
+++ b/authors/settings/staging.py
@@ -1,0 +1,17 @@
+import os
+from authors.settings.base import *
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = config('DEBUG')
+
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': config('DB_NAME', default = 'legion_backend'),
+        'USER': config('DB_USER', default = 'legion'),
+        'PASSWORD': config('DB_PASSWORD', default = '&L3g10n'),
+        'HOST': config('DB_HOST'),
+        'PORT': '',
+    }
+}

--- a/authors/settings/test.py
+++ b/authors/settings/test.py
@@ -1,0 +1,17 @@
+import os
+from authors.settings.base import *
+
+# SECURITY WARNING: don't run with debug turned on in production!
+DEBUG = True
+
+SENDING_MAIL = False
+
+# Database
+# https://docs.djangoproject.com/en/1.11/ref/settings/#databases
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.sqlite3',
+        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,10 @@
+dj-database-url==0.5.0
 Django==2.1.7
 django-cors-middleware==1.3.1
 django-extensions==2.1.6
 djangorestframework==3.9.1
+psycopg2-binary==2.7.7
+PyJWT==1.4.2
+python-decouple==3.1
+pytz==2018.9
+six==1.10.0


### PR DESCRIPTION
#### What does this PR do?
This configures  [legion's backend](https://github.com/andela/ah-legion-backend) to run on Postgresql instead of the default SQLite.

#### Description of Task to be completed?
- configure the app's backend to run on Postgresql as the database engine.
- install psycopg2 and python-decouple.
- set postgresql url info in settings.py file.
-update readme to include instructions on running,configuring and running the app

#### How should this be manually tested?
  **To run the app in testing environment:**
  
      STEP 1: Git clone this specific branch `git clone -b ch-configure-postgresql-164046241 
                     git@github.com:BrianSerem/Andela/ah-legion-backend.git`
      STEP 2: Create a virtual environment and activate it.
      STEP 3: Install all the dependencies by running `pip install -r requirements.txt`
      STEP 4: Start the app by running `python manage.py runserver --settings=authors.settings.test` 

  **To run server :**
      Follow the above steps, on step 4, start the server by running `python manage.py runserver  --settings=authors.settings.dev`

#### Any background context you want to provide?
- you should first install postgres on your working environment. 
- python-decouple handles  environment variables, use the format shown in the picture below when defining them inside your .env file: 
-dj-database-url handles database credentials for the production server.
-testing server uses sqlite as the database engine.
<img width="1080" alt="screenshot 2019-02-27 at 07 49 13" src="https://user-images.githubusercontent.com/44457835/53466769-5cd34100-3a64-11e9-81cf-e80a2b69e2e9.png">

#### What are the relevant pivotal tracker stories?

https://www.pivotaltracker.com/story/show/164046241

