### PR TITLE
#164046250 Implement CRUD on User Profiles

### DIFF
--- a/authors/apps/authentication/renderers.py
+++ b/authors/apps/authentication/renderers.py
@@ -19,6 +19,13 @@ class UserJSONRenderer(JSONRenderer):
             return super().render(data)
 
         # Finally, we can render our data under the "user" namespace.
+        image_prefix = "https://res.cloudinary.com/dbsri2qtr/"
+        try:
+            image_suffix = data['profile']['image']
+            data['profile']['image'] = image_prefix + image_suffix
+
+        except KeyError:
+            pass
         return json.dumps({
             'user': data
         })

--- a/authors/apps/authentication/tests/test_jwt.py
+++ b/authors/apps/authentication/tests/test_jwt.py
@@ -10,8 +10,10 @@ from authors.apps.authentication.backends import JWTAuthentication
 
 class JWTAuthenticationTest(TestCase):
     """Test the JWT Authentication implementation"""
+
     def setUp(self):
-        self.user = User.objects.create(username='user1', email='user1@mail.com', password='password')
+        self.user = User.objects.create(
+            username='user1', email='user1@mail.com', password='password')
         self.login_data = {'user': {
             'email': 'user2@mail.com',
             'password': 'password'
@@ -27,7 +29,8 @@ class JWTAuthenticationTest(TestCase):
             'username': 'user2',
             'password': 'password'
         }}, format='json')
-        res = self.client.post(reverse('authentication:login'), self.login_data, format='json')
+        res = self.client.post(
+            reverse('authentication:login'), self.login_data, format='json')
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertIn('token', res.data)
 
@@ -41,7 +44,8 @@ class JWTAuthenticationTest(TestCase):
         """Test if a user can access a secured endpoint without providing a token"""
         res = self.client.get(reverse('authentication:get users'))
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(res.data['detail'], 'Authentication credentials were not provided.')
+        self.assertEqual(
+            res.data['detail'], 'Authentication credentials were not provided.')
 
     def test_failure_if_user_provides_invalid_token(self):
         """Test if an invalid token can be decoded"""
@@ -49,28 +53,33 @@ class JWTAuthenticationTest(TestCase):
         headers = {'HTTP_AUTHORIZATION': f'Bearer {fake_token}'}
         res = self.client.get(reverse('authentication:get users'), **headers)
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(res.data['detail'], 'Ivalid token provided. Authentication failure.')
+        self.assertEqual(
+            res.data['detail'], 'Ivalid token provided. Authentication failure.')
 
     def test_failure_if_user_does_not_exist(self):
         """We register a user to get the token, then delete the user from the database. When a user tries to pass the token to access the endpoint, they should be forbidden from proceeding."""
-        test_user = User.objects.create(username='test_user', email='test_user@mail.com', password='password')
+        test_user = User.objects.create(
+            username='test_user', email='test_user@mail.com', password='password')
         test_token = test_user.token
         test_user.delete()
         client = APIClient()
         headers = {'HTTP_AUTHORIZATION': f'Bearer {test_token}'}
         res = client.get(reverse('authentication:get users'), **headers)
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(res.data['detail'], 'User matching this token was not found.')
+        self.assertEqual(res.data['detail'],
+                         'User matching this token was not found.')
 
     def test_failure_because_user_is_inactive(self):
         """Test if an inactive user can be authenticated"""
-        inactive_user = User.objects.create(username='inactive_one', email='inactive@mail.com', password='password')
+        inactive_user = User.objects.create(
+            username='inactive_one', email='inactive@mail.com', password='password')
         inactive_user.is_active = False
         inactive_user.save()
         headers = {'HTTP_AUTHORIZATION': f'Bearer {inactive_user.token}'}
         res = self.client.get(reverse('authentication:get users'), **headers)
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(res.data['detail'], 'Forbidden! This user has been deactivated.')
+        self.assertEqual(res.data['detail'],
+                         'Forbidden! This user has been deactivated.')
 
     def test_authentication_failure_because_header_is_None(self):
         """Test if authentication fails when a request has authorization

--- a/authors/apps/authentication/tests/test_models.py
+++ b/authors/apps/authentication/tests/test_models.py
@@ -2,43 +2,51 @@ from django.test import TestCase
 
 from authors.apps.authentication.models import User
 
+
 class UserManagerTest(TestCase):
     """This class defines tests for UserManager class"""
+
     def test_successfully_create_user(self):
         """"""
-        user1 = User.objects.create_user(username="user1", email="user1@mail.com", password="password")
+        user1 = User.objects.create_user(
+            username="user1", email="user1@mail.com", password="password")
         self.assertIsInstance(user1, User)
 
     def test_registration_failure_due_to_no_username(self):
         """Test if user can register without a username"""
         with self.assertRaises(TypeError) as e:
-            User.objects.create_user(email="user1@mail.com", username=None, password="password")
+            User.objects.create_user(
+                email="user1@mail.com", username=None, password="password")
         self.assertEqual(str(e.exception), 'Users must have a username.')
-
 
     def test_registration_failure_due_to_no_email(self):
         """Test if a user can register without an email"""
         with self.assertRaises(TypeError) as e:
-            User.objects.create_user(username="user2", email=None, password="password")
+            User.objects.create_user(
+                username="user2", email=None, password="password")
         self.assertEqual(str(e.exception), 'Users must have an email address.')
 
     def test_registration_superuser_fail_due_to_no_password(self):
         """Test if a superuser can register without a password"""
         with self.assertRaises(TypeError) as e:
-            User.objects.create_superuser(username="superuser", email="superuser@mail.com", password=None)
+            User.objects.create_superuser(
+                username="superuser", email="superuser@mail.com", password=None)
         self.assertEqual(str(e.exception), 'Superusers must have a password.')
 
     def test_successfully_create_superuser(self):
         """Test if we can successfully create a superuser"""
-        user1 = User.objects.create_superuser(username="superuser", email="superuser@mail.com", password="password")
+        user1 = User.objects.create_superuser(
+            username="superuser", email="superuser@mail.com", password="password")
         self.assertTrue(user1.is_superuser)
         self.assertTrue(user1.is_staff)
 
 
 class UserTest(TestCase):
     """This class defines tests for user models"""
+
     def setUp(self):
-        self.user1 = User.objects.create_user(username="user", email="user@mail.com", password="password")
+        self.user1 = User.objects.create_user(
+            username="user", email="user@mail.com", password="password")
 
     def test_user_string_representation(self):
         """Test if proper string representation is returned for users"""

--- a/authors/apps/authentication/tests/test_serializers.py
+++ b/authors/apps/authentication/tests/test_serializers.py
@@ -10,6 +10,7 @@ from authors.apps.authentication.serializers import (LoginSerializer,
 
 class RegistrationSerializerTests(TestCase):
     """This class defines tests for the RegistrationSerializer class"""
+
     def setUp(self):
         self.user_data = {
             "username": "bob",
@@ -27,6 +28,7 @@ class RegistrationSerializerTests(TestCase):
 
 class LoginSerializerTests(TestCase):
     """This class defines tests for the LoginSerializer class"""
+
     def test_validating_login_serializer_without_email(self):
         """Test if users can login without providing an email"""
         login_data = {"password": "hardpassword"}
@@ -81,7 +83,7 @@ class UserSerializersTests(TestCase):
 
     def setUp(self):
         self.user = User.objects.create_user(username="bob", email="bob@email.com",
-                                        password="hardpassword")
+                                             password="hardpassword")
         self.user.save()
         self.serializer = UserSerializer()
 

--- a/authors/apps/authentication/tests/test_user_registration.py
+++ b/authors/apps/authentication/tests/test_user_registration.py
@@ -36,7 +36,8 @@ class RegistrationTestCase(APITestCase):
             "username": ["Username field cannot be blank"]
         }
         }
-        response = self.client.post(self.url, blank_username_data, format='json')
+        response = self.client.post(
+            self.url, blank_username_data, format='json')
         self.assertEqual(response.data, blank_username_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -52,7 +53,8 @@ class RegistrationTestCase(APITestCase):
             "username": ["Username is required"]
         }
         }
-        response = self.client.post(self.url, no_username_field_data, format='json')
+        response = self.client.post(
+            self.url, no_username_field_data, format='json')
         self.assertEqual(response.data, no_username_field_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -77,7 +79,8 @@ class RegistrationTestCase(APITestCase):
         }
         }
         self.client.post(self.url, username_data, format='json')
-        response = self.client.post(self.url, existing_username_data, format='json')
+        response = self.client.post(
+            self.url, existing_username_data, format='json')
         self.assertEqual(response.data, existing_username_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -110,7 +113,8 @@ class RegistrationTestCase(APITestCase):
             "email": ["Email is required"]
         }
         }
-        response = self.client.post(self.url, no_email_field_data, format='json')
+        response = self.client.post(
+            self.url, no_email_field_data, format='json')
         self.assertEqual(response.data, no_email_field_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -152,7 +156,8 @@ class RegistrationTestCase(APITestCase):
         }
         }
         self.client.post(self.url, email_data, format='json')
-        response = self.client.post(self.url, existing_email_data, format='json')
+        response = self.client.post(
+            self.url, existing_email_data, format='json')
         self.assertEqual(response.data, existing_email_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -169,7 +174,8 @@ class RegistrationTestCase(APITestCase):
             "password": ["Password field cannot be blank"]
         }
         }
-        response = self.client.post(self.url, blank_password_data, format='json')
+        response = self.client.post(
+            self.url, blank_password_data, format='json')
         self.assertEqual(response.data, blank_password_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -185,7 +191,8 @@ class RegistrationTestCase(APITestCase):
             "password": ["Password is required"]
         }
         }
-        response = self.client.post(self.url, no_password_field_data, format='json')
+        response = self.client.post(
+            self.url, no_password_field_data, format='json')
         self.assertEqual(response.data, no_password_field_data_response)
 
     def test_not_alphanumeric_password(self):
@@ -201,7 +208,8 @@ class RegistrationTestCase(APITestCase):
             "password": ["Password should be alphanumeric"]
         }
         }
-        response = self.client.post(self.url, not_alphanumeric_password_data, format='json')
+        response = self.client.post(
+            self.url, not_alphanumeric_password_data, format='json')
         self.assertEqual(response.data, not_alphanumeric_password_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -218,7 +226,8 @@ class RegistrationTestCase(APITestCase):
             "password": ["Password should be at least 8 characters long"]
         }
         }
-        response = self.client.post(self.url, not_alphanumeric_password_data, format='json')
+        response = self.client.post(
+            self.url, not_alphanumeric_password_data, format='json')
         self.assertEqual(response.data, not_alphanumeric_password_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -235,6 +244,7 @@ class RegistrationTestCase(APITestCase):
             "password": ["Password should not be longer than 128 characters"]
         }
         }
-        response = self.client.post(self.url, not_alphanumeric_password_data, format='json')
+        response = self.client.post(
+            self.url, not_alphanumeric_password_data, format='json')
         self.assertEqual(response.data, not_alphanumeric_password_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/authors/apps/authentication/tests/test_views.py
+++ b/authors/apps/authentication/tests/test_views.py
@@ -4,29 +4,34 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient, force_authenticate
 
+
 class RegistrationViewTest(TestCase):
     """This class defines tests for the RegistrationView class"""
+
     def setUp(self):
         self.user1 = {"user":
-                            {"email": "user1@mail.com",
-                            "username": "user1",
-                            "password": "password"}
-                    }
+                      {"email": "user1@mail.com",
+                       "username": "user1",
+                       "password": "password"}
+                      }
 
     def test_user_can_register(self):
         """Test if a user is able to register"""
         client = APIClient()
-        response = client.post(reverse('authentication:register'), self.user1, format='json')
+        response = client.post(
+            reverse('authentication:register'), self.user1, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
 
 class LoginViewTest(TestCase):
     """This class defines tests for the LoginView class"""
+
     def setUp(self):
         self.user1 = {"user":
-        {"email": "user1@mail.com",
-         "username": "user1",
-          "password": "password"}
-          }
+                      {"email": "user1@mail.com",
+                       "username": "user1",
+                       "password": "password"}
+                      }
         self.user1_credentials = {"user": {
             "email": "user1@mail.com",
             "password": "password"
@@ -35,22 +40,27 @@ class LoginViewTest(TestCase):
     def test_registered_user_can_log_in(self):
         """Test if a registered user can log in"""
         client = APIClient()
-        client.post(reverse('authentication:register'), self.user1, format='json')
-        response = client.post(reverse('authentication:login'), self.user1_credentials, format='json')
+        client.post(reverse('authentication:register'),
+                    self.user1, format='json')
+        response = client.post(reverse('authentication:login'),
+                               self.user1_credentials, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
 
 class UserRetrieveUpdateAPITest(TestCase):
     """This class defines tests for the UserRetrieveUpdateAPIView"""
+
     def test_if_we_can_retrieve_user_list(self):
         """Test if a logged in user can retrieve a user list"""
         user1 = {"user":
-        {"email": "user1@mail.com",
-            "username": "user1",
-            "password": "password"}
-            }
+                 {"email": "user1@mail.com",
+                  "username": "user1",
+                  "password": "password"}
+                 }
         client = APIClient()
         client.post(reverse('authentication:register'), user1, format='json')
-        login_data = client.post(reverse('authentication:login'), {'user':{"email": "user1@mail.com", "password":"password"}}, format='json')
+        login_data = client.post(reverse('authentication:login'), {
+                                 'user': {"email": "user1@mail.com", "password": "password"}}, format='json')
         token = login_data.data['token']
         headers = {'HTTP_AUTHORIZATION': f'Bearer {token}'}
         response = client.get(reverse('authentication:get users'), **headers)
@@ -59,10 +69,10 @@ class UserRetrieveUpdateAPITest(TestCase):
     def test_if_we_can_update_user_data(self):
         """Test if we can update the user data"""
         user1 = {"user":
-        {"email": "user1@mail.com",
-            "username": "user1",
-            "password": "password"}
-            }
+                 {"email": "user1@mail.com",
+                  "username": "user1",
+                  "password": "password"}
+                 }
 
         update_info = {"user": {
             "email": "user1@mail.com",
@@ -71,7 +81,8 @@ class UserRetrieveUpdateAPITest(TestCase):
         }}
         client = APIClient()
         client.post(reverse('authentication:register'), user1, format='json')
-        login_data = client.post(reverse('authentication:login'), {'user':{"email": "user1@mail.com", "password":"password"}}, format='json')
+        login_data = client.post(reverse('authentication:login'), {
+                                 'user': {"email": "user1@mail.com", "password": "password"}}, format='json')
         token = login_data.data['token']
         headers = {'HTTP_AUTHORIZATION': f'Bearer {token}'}
         response = client.put(reverse('authentication:get users'), **headers)

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -61,21 +61,11 @@ class LoginAPIView(APIView):
 
 
 class UserRetrieveUpdateAPIView(RetrieveUpdateAPIView):
-    """
-    get:
-        Retrieve details of a user
-
-    put:
-        Update all details of a user
-
-    patch:
-        Update a single detail of a user
-    """
     permission_classes = (IsAuthenticated,)
     renderer_classes = (UserJSONRenderer,)
     serializer_class = UserSerializer
 
-    def retrieve(self, request, *args, **kwargs):
+    def get(self, request, *args, **kwargs):
         # There is nothing to validate or save here. Instead, we just want the
         # serializer to handle turning our `User` object into something that
         # can be JSONified and sent to the client.
@@ -85,11 +75,35 @@ class UserRetrieveUpdateAPIView(RetrieveUpdateAPIView):
 
     def update(self, request, *args, **kwargs):
         serializer_data = request.data.get('user', {})
+        user_data = {
+            'username': serializer_data.get('username', request.user.username),
+            'email': serializer_data.get('email', request.user.email),
+            'profile': {
+                'first_name': serializer_data.get(
+                    'first_name', request.user.profile.first_name),
+                'last_name': serializer_data.get(
+                    'last_name', request.user.profile.last_name),
+                'birth_date': serializer_data.get(
+                    'birth_date', request.user.profile.birth_date),
+                'bio': serializer_data.get('bio', request.user.profile.bio),
+                'image': serializer_data.get(
+                    'image', request.user.profile.image),
+                'city': serializer_data.get(
+                    'city', request.user.profile.city),
+                'country': serializer_data.get(
+                    'country', request.user.profile.country),
+                'phone': serializer_data.get(
+                    'phone', request.user.profile.phone),
+                'website': serializer_data.get(
+                    'website', request.user.profile.website),
+
+            }
+        }
 
         # Here is that serialize, validate, save pattern we talked about
         # before.
         serializer = self.serializer_class(
-            request.user, data=serializer_data, partial=True
+            request.user, data=user_data, partial=True
         )
         serializer.is_valid(raise_exception=True)
         serializer.save()

--- a/authors/apps/core/models.py
+++ b/authors/apps/core/models.py
@@ -1,0 +1,8 @@
+from django.db import models
+from django.utils.translation import ugettext_lazy as _
+
+
+class TimeStampModel(models.Model):
+    created_at = models.DateTimeField(_('created at'), auto_now_add=True)
+    updated_at = models.DateTimeField(
+        _('updated at'), auto_now_add=False, auto_now=True)

--- a/authors/apps/profiles/exceptions.py
+++ b/authors/apps/profiles/exceptions.py
@@ -1,0 +1,11 @@
+from rest_framework.exceptions import APIException
+
+
+class ProfileDoesNotExist(APIException):
+    status_code = 400
+    default_detail = 'The requested profile does not exist.'
+
+
+class UserIsNotAuthenticated(APIException):
+    status_code = 403
+    default_detail = 'You should be logged in to proceed.'

--- a/authors/apps/profiles/models.py
+++ b/authors/apps/profiles/models.py
@@ -1,0 +1,48 @@
+from django.conf import settings
+from django.db import models
+from django.db.models.signals import post_save
+from authors.apps.core.models import TimeStampModel
+from cloudinary.models import CloudinaryField
+
+
+class Profile(TimeStampModel):
+    user = models.OneToOneField(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
+    first_name = models.CharField(
+        'first name', max_length=30, blank=True, null=True)
+    last_name = models.CharField(
+        'last name', max_length=30, blank=True, null=True)
+    birth_date = models.DateField('last name', null=True, blank=True)
+    bio = models.TextField('bio', default='', null=True, blank=True)
+    city = models.CharField('city', blank=True, null=True,
+                            max_length=100, default='')
+    country = models.CharField('country', blank=True,
+                               null=True, max_length=100, default='')
+    phone = models.IntegerField('phone', blank=True, null=True, default=0)
+    website = models.URLField('website', blank=True, null=True, default='')
+    image = CloudinaryField('image', default="cat.jpg")  # noflake8
+
+    def __str__(self):
+        return self.user.username
+
+    @property
+    def get_username(self):
+        return self.user.username
+
+    def get_email(self):
+        return self.user.email
+
+
+"""
+Signal receiver for 'post_save' signal sent by User model upon saving
+"""
+
+
+def create_profile(sender, **kwargs):
+    if kwargs.get('created'):
+        user_profile = Profile(user=kwargs.get('instance'))
+        user_profile.save()
+
+
+# connect the signal to the handler function
+post_save.connect(create_profile, sender=settings.AUTH_USER_MODEL)

--- a/authors/apps/profiles/renderers.py
+++ b/authors/apps/profiles/renderers.py
@@ -1,0 +1,33 @@
+import json
+
+from rest_framework.renderers import JSONRenderer
+
+
+class ProfileJSONRenderer(JSONRenderer):
+    charset = 'utf-8'
+
+    def render(self, data, media_type=None, renderer_context=None):
+        """
+        Check for errors key in data
+        """
+        errors = data.get('errors', None)
+
+        if errors:
+            """
+            We will let the default JSONRenderer handle
+            rendering errors.
+            """
+            return super(ProfileJSONRenderer, self).render(data)
+
+        # Finally, we can render our data under the "profile" namespace.
+        image_prefix = "https://res.cloudinary.com/dbsri2qtr"
+        try:
+            image_suffix = data['image']
+            data['image'] = image_prefix + image_suffix
+
+        except KeyError:
+            pass
+
+        return json.dumps({
+            'profile': data
+        })

--- a/authors/apps/profiles/serializers.py
+++ b/authors/apps/profiles/serializers.py
@@ -1,0 +1,16 @@
+from rest_framework import serializers
+
+from .models import Profile
+
+
+class ProfileSerializer(serializers.ModelSerializer):
+    username = serializers.ReadOnlyField(source='get_username')
+    email = serializers.ReadOnlyField(source='get_email')
+
+    class Meta:
+        model = Profile
+        fields = [
+            'username', 'first_name', 'last_name', 'email', 'birth_date', 'bio',
+            'image', 'city', 'country', 'phone', 'website', 'created_at',
+            'updated_at'
+        ]

--- a/authors/apps/profiles/tests/test_models.py
+++ b/authors/apps/profiles/tests/test_models.py
@@ -1,0 +1,23 @@
+from django.test import TestCase
+
+from ..models import Profile
+from authors.apps.authentication.models import User
+
+
+class TestProfile(TestCase):
+    """ class to test the profile models"""
+
+    def setUp(self):
+        """ Setup some code that is used by the unittests"""
+        self.email = 'serem@gmail.com'
+        self.username = 'tesiting'
+        self.password = 'jcbsdhcvshucj!!'
+
+        # create a user that will be logged in
+        self.user = User.objects.create_user(
+            self.username, self.email, self.password)
+        self.profile = self.user.profile
+
+    def test_string_representation(self):
+        """ test for the value returned by __str__ """
+        self.assertEqual(str(self.profile), self.username)

--- a/authors/apps/profiles/tests/test_views.py
+++ b/authors/apps/profiles/tests/test_views.py
@@ -1,0 +1,110 @@
+from django.test import TestCase, Client
+
+import json
+
+from authors.apps.authentication.models import User
+from authors.apps.profiles.models import Profile
+from authors.apps.profiles.renderers import ProfileJSONRenderer
+
+
+class TestProfileViews(TestCase):
+    def setUp(self):
+        """ Funtion to setup some code that will be needed for unittests """
+        self.email = 'boomboom@gmail.com'
+        self.username = 'testing12'
+        self.password = 'testuserpass'
+
+        # create a user that will be logged in
+        self.user = User.objects.create_user(
+            self.username, self.email, self.password)
+
+        # verify a user's account and save
+        self.user.is_verified = True
+        self.user.save()
+
+        self.data = {
+            'user': {
+                'username': self.username,
+                'email': self.email,
+                'password': self.password,
+            }
+        }
+        self.updated_data = {
+            'user': {
+                'username': "newname",
+                'email': "another@email.com",
+                'password': "otherpaswword",
+            }
+        }
+
+        self.test_client = Client()
+
+        token = self.login_a_user()
+        headers = {'HTTP_AUTHORIZATION': 'Bearer ' + token}
+
+    def tearDown(self):
+        pass
+
+    def login_a_user(self):
+        """
+        Reusable function to login a user
+        """
+
+        response = self.test_client.post(
+            "/api/users/login/", data=json.dumps(self.data), content_type='application/json')
+        token = response.json()['user']['token']
+        return token
+
+    def register_user(self, user_details_dict):
+        """ Register anew user to the system
+
+        Args:
+            user_details_dict: a dictionary with username, email, password of the user
+
+        Returns: an issued post request to the user registration endpoint
+        """
+        return self.test_client.post(
+            "/api/users/", data=json.dumps(user_details_dict), content_type='application/json')
+
+    @property
+    def token(self):
+        return self.login_a_user()
+
+    def test_retrieve_profile(self):
+        """ test for the retrive profile endpoint """
+        token = self.login_a_user()
+        headers = {'HTTP_AUTHORIZATION': 'Bearer ' + token}
+        response = self.test_client.get(
+            "/api/profiles/{}/".format(self.username), **headers, content_type='application/json')
+
+        self.assertEqual(response.status_code, 200)
+
+    def test_update_existing_profie(self):
+        """ test for updating exisiting user profile"""
+        token = self.login_a_user()
+        headers = {'HTTP_AUTHORIZATION': 'Bearer ' + token}
+        self.register_user(self.data)
+        response = self.test_client.put(
+            "/api/user/", **headers, content_type='application/json', data=json.dumps(self.updated_data))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json()['user']['email'], "another@email.com")
+        self.assertEqual(response.json()['user']['username'], "newname")
+
+    def test_list_all_profiles(self):
+        """ test for checking if app returns all available profiles """
+        token = self.login_a_user()
+        headers = {'HTTP_AUTHORIZATION': 'Bearer ' + token}
+        response = self.client.get(
+            "/api/profiles/", **headers, content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+
+    def test_get_non_existing_profile(self):
+        """ test for checking if app catches non-existing profile error """
+        token = self.login_a_user()
+        headers = {'HTTP_AUTHORIZATION': 'Bearer ' + token}
+        response = self.client.get(
+            "/api/profiles/serdgddddadscw/", **headers, content_type='application/json')
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json()['profile']['detail'], "The requested profile does not exist.")

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from .views import ProfileRetrieveAPIView, ProfileListApiView
+
+app_name = 'profiles'
+
+urlpatterns = [
+    path('profiles/<username>/', ProfileRetrieveAPIView.as_view()),
+    path('profiles/', ProfileListApiView.as_view()),
+]

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -1,0 +1,43 @@
+from rest_framework import status
+from rest_framework.generics import RetrieveAPIView, ListAPIView
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from drf_yasg.utils import swagger_auto_schema
+
+from .models import Profile
+from .renderers import ProfileJSONRenderer
+from .serializers import ProfileSerializer
+from .exceptions import ProfileDoesNotExist
+
+
+class ProfileRetrieveAPIView(RetrieveAPIView):
+    """
+    Class endpoint for retreving a single user profile
+    """
+    permission_classes = (IsAuthenticated,)
+    renderer_classes = (ProfileJSONRenderer,)
+    serializer_class = ProfileSerializer
+
+    @swagger_auto_schema(query_serializer=serializer_class,
+                         responses={201: serializer_class()})
+    def get(self, request, username, *args, **kwargs):
+        """ function to retrieve a requested profile """
+        try:
+            profile = Profile.objects.select_related('user').get(
+                user__username=username
+            )
+        except Profile.DoesNotExist:
+            raise ProfileDoesNotExist
+
+        serializer = self.serializer_class(profile)
+
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class ProfileListApiView(ListAPIView):
+    """
+    Class endpoint for retreving a single user profile
+    """
+    queryset = Profile.objects.all()
+    permission_classes = (IsAuthenticated,)
+    serializer_class = ProfileSerializer

--- a/authors/settings/base.py
+++ b/authors/settings/base.py
@@ -47,7 +47,7 @@ INSTALLED_APPS = [
 ]
 MIDDLEWARE_CLASSES = (
     'whitenoise.middleware.WhiteNoiseMiddleware',
-    )
+)
 
 MIDDLEWARE = [
     'django.contrib.sessions.middleware.SessionMiddleware',

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -42,6 +42,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/', include('authors.apps.authentication.urls',
                          namespace='authentication')),
+    path('api/', include('authors.apps.profiles.urls',
+                         namespace='profiles')),
     url(r'^swagger(?P<format>\.json|\.yaml)$',
         schema_view.without_ui(cache_timeout=0),
         name='schema-json'),
@@ -50,4 +52,3 @@ urlpatterns = [
     url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0),
         name='schema-redoc'),
 ]
-


### PR DESCRIPTION
#### What does this PR do?
This implements CRUD on user profiles model. It adds the ability for newly created users to have their profiles upon successful* registration.

#### Description of Task to be completed?
1. Writing of tests covering CRUD on profiles model
2. Creation of profiles model.
3. Implementation of CRUD on user profiles.
4. Verification of tests.

The following endpoints are now working:

**GET** `/api/profiles/`                        - Get all profiles
**GET** `/api/profiles/username/`      - Get a single profile
**PUT** `/api/users/`                           - Edit the profile of currently logged in user



#### How should this be manually tested?
Using Postman, use this production server link.

#### Any background context you want to provide?
*successful registration means a user has already been verified, to be added later.
Users may edit their own profiles only.
Anyone may view all/single profile(s)

#### What are the relevant pivotal tracker stories?
[#164046250](https://www.pivotaltracker.com/n/projects/2313280/stories/164046250)



[Finishes #164046250]