### PR TITLE
[#164046247] Users can verify their accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ migrations/
 .DS_Store
 .vscode/
 staticfiles/
+sendgrid.env

--- a/authors/apps/authentication/models.py
+++ b/authors/apps/authentication/models.py
@@ -45,6 +45,7 @@ class UserManager(BaseUserManager):
         user = self.create_user(username, email, password)
         user.is_superuser = True
         user.is_staff = True
+        user.is_verified = True
         user.save()
 
         return user
@@ -70,6 +71,7 @@ class User(AbstractBaseUser, PermissionsMixin):
     # but we can still analyze the data.
     is_active = models.BooleanField(default=True)
 
+    # users must verify their accounts before they are able to log in.
     is_verified = models.BooleanField(default=False)
 
     # The `is_staff` flag is expected by Django to determine who can and cannot

--- a/authors/apps/authentication/templates/email_verification.html
+++ b/authors/apps/authentication/templates/email_verification.html
@@ -1,0 +1,36 @@
+<div style="padding:0;margin:0 auto;width:100%!important;
+font-family:Helvetica,Arial,sans-serif">
+    <table style="background-color:#c8d1da;table-layout:fixed" align="center" cellspacing="0" cellpadding="0" width="90%" border="0" bgcolor="#edf0f3">
+        <tbody>
+            <tr>
+                <td align="center" style="font-weight: bold;font-size: 18px;background-color:rgb(174, 206, 255);padding:10px;border-bottom:1px solid #bebebe">
+                    Hi {{ username }}
+                </td>
+            </tr>
+            <tr align="center">
+                <td style="padding:12px;background: #F6F8FA">
+                    <div>
+                        <p>Thank you for creating an account with us at Author's Heaven
+                            <br/> Please verify your email address by clicking the link below
+                        </p>
+                        <br/>
+                        <a href="{{ domain }}/api/activate/{{ token }}" style="background:#065cdd;color:#f6f7f8;text-decoration: none;padding: 10px;border-radius:  5px;">Click here to verify email</a>
+                        <br/>
+                        <br/>
+                        <p>OR
+                            <br/>
+                            <br/>Copy and paste this link in your browser
+                            <br/>
+                            <br/>
+                            <a style="color:#2876ec; overflow: visble;"> {{ domain }}/api/activate/{{ token }}</a>
+                        </p>
+                        <p>
+                            <strong>This is an autogenerate email that was sent when you created an account with us. If this was not you, kindly ingore the email. Please do not reply.</strong>
+                        </p>
+                        <br/>
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>

--- a/authors/apps/authentication/tests/test_jwt.py
+++ b/authors/apps/authentication/tests/test_jwt.py
@@ -10,8 +10,10 @@ from authors.apps.authentication.backends import JWTAuthentication
 
 class JWTAuthenticationTest(TestCase):
     """Test the JWT Authentication implementation"""
+
     def setUp(self):
-        self.user = User.objects.create(username='user1', email='user1@mail.com', password='password')
+        self.user = User.objects.create(
+            username='user1', email='user1@mail.com', password='password')
         self.login_data = {'user': {
             'email': 'user2@mail.com',
             'password': 'password'
@@ -22,14 +24,15 @@ class JWTAuthenticationTest(TestCase):
 
     def test_user_gets_a_token_when_they_log_in(self):
         """Users should get a token when they successfully log in"""
-        self.client.post(reverse('authentication:register'), {'user': {
-            'email': 'user2@mail.com',
-            'username': 'user2',
-            'password': 'password'
-        }}, format='json')
-        res = self.client.post(reverse('authentication:login'), self.login_data, format='json')
-        self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertIn('token', res.data)
+        client = APIClient()
+        user2 = User.objects.create_user(
+            username='user2', email='user2@mail.com', password='password')
+        user2.is_verified = True
+        user2.save()
+        response = client.post(reverse('authentication:login'), {
+                               'user': {'email': 'user2@mail.com', 'password': 'password'}}, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('token', response.data)
 
     def test_if_user_passes_valid_token_to_access_secured_endpoint(self):
         """Test if a user can access a secured endpoint after providing a valid token"""
@@ -41,7 +44,8 @@ class JWTAuthenticationTest(TestCase):
         """Test if a user can access a secured endpoint without providing a token"""
         res = self.client.get(reverse('authentication:get users'))
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(res.data['detail'], 'Authentication credentials were not provided.')
+        self.assertEqual(
+            res.data['detail'], 'Authentication credentials were not provided.')
 
     def test_failure_if_user_provides_invalid_token(self):
         """Test if an invalid token can be decoded"""
@@ -49,28 +53,33 @@ class JWTAuthenticationTest(TestCase):
         headers = {'HTTP_AUTHORIZATION': f'Bearer {fake_token}'}
         res = self.client.get(reverse('authentication:get users'), **headers)
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(res.data['detail'], 'Invalid token provided. Authentication failure.')
+        self.assertEqual(
+            res.data['detail'], 'Invalid token provided. Authentication failure.')
 
     def test_failure_if_user_does_not_exist(self):
         """We register a user to get the token, then delete the user from the database. When a user tries to pass the token to access the endpoint, they should be forbidden from proceeding."""
-        test_user = User.objects.create(username='test_user', email='test_user@mail.com', password='password')
+        test_user = User.objects.create(
+            username='test_user', email='test_user@mail.com', password='password')
         test_token = test_user.token
         test_user.delete()
         client = APIClient()
         headers = {'HTTP_AUTHORIZATION': f'Bearer {test_token}'}
         res = client.get(reverse('authentication:get users'), **headers)
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(res.data['detail'], 'User matching this token was not found.')
+        self.assertEqual(res.data['detail'],
+                         'User matching this token was not found.')
 
     def test_failure_because_user_is_inactive(self):
         """Test if an inactive user can be authenticated"""
-        inactive_user = User.objects.create(username='inactive_one', email='inactive@mail.com', password='password')
+        inactive_user = User.objects.create(
+            username='inactive_one', email='inactive@mail.com', password='password')
         inactive_user.is_active = False
         inactive_user.save()
         headers = {'HTTP_AUTHORIZATION': f'Bearer {inactive_user.token}'}
         res = self.client.get(reverse('authentication:get users'), **headers)
         self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
-        self.assertEqual(res.data['detail'], 'Forbidden! This user has been deactivated.')
+        self.assertEqual(res.data['detail'],
+                         'Forbidden! This user has been deactivated.')
 
     def test_authentication_failure_because_header_is_None(self):
         """Test if authentication fails when a request has authorization

--- a/authors/apps/authentication/tests/test_models.py
+++ b/authors/apps/authentication/tests/test_models.py
@@ -2,43 +2,51 @@ from django.test import TestCase
 
 from authors.apps.authentication.models import User
 
+
 class UserManagerTest(TestCase):
     """This class defines tests for UserManager class"""
+
     def test_successfully_create_user(self):
         """"""
-        user1 = User.objects.create_user(username="user1", email="user1@mail.com", password="password")
+        user1 = User.objects.create_user(
+            username="user1", email="user1@mail.com", password="password")
         self.assertIsInstance(user1, User)
 
     def test_registration_failure_due_to_no_username(self):
         """Test if user can register without a username"""
         with self.assertRaises(TypeError) as e:
-            User.objects.create_user(email="user1@mail.com", username=None, password="password")
+            User.objects.create_user(
+                email="user1@mail.com", username=None, password="password")
         self.assertEqual(str(e.exception), 'Users must have a username.')
-
 
     def test_registration_failure_due_to_no_email(self):
         """Test if a user can register without an email"""
         with self.assertRaises(TypeError) as e:
-            User.objects.create_user(username="user2", email=None, password="password")
+            User.objects.create_user(
+                username="user2", email=None, password="password")
         self.assertEqual(str(e.exception), 'Users must have an email address.')
 
     def test_registration_superuser_fail_due_to_no_password(self):
         """Test if a superuser can register without a password"""
         with self.assertRaises(TypeError) as e:
-            User.objects.create_superuser(username="superuser", email="superuser@mail.com", password=None)
+            User.objects.create_superuser(
+                username="superuser", email="superuser@mail.com", password=None)
         self.assertEqual(str(e.exception), 'Superusers must have a password.')
 
     def test_successfully_create_superuser(self):
         """Test if we can successfully create a superuser"""
-        user1 = User.objects.create_superuser(username="superuser", email="superuser@mail.com", password="password")
+        user1 = User.objects.create_superuser(
+            username="superuser", email="superuser@mail.com", password="password")
         self.assertTrue(user1.is_superuser)
         self.assertTrue(user1.is_staff)
 
 
 class UserTest(TestCase):
     """This class defines tests for user models"""
+
     def setUp(self):
-        self.user1 = User.objects.create_user(username="user", email="user@mail.com", password="password")
+        self.user1 = User.objects.create_user(
+            username="user", email="user@mail.com", password="password")
 
     def test_user_string_representation(self):
         """Test if proper string representation is returned for users"""

--- a/authors/apps/authentication/tests/test_serializers.py
+++ b/authors/apps/authentication/tests/test_serializers.py
@@ -1,20 +1,25 @@
 from django.test import TestCase
 
 from rest_framework.serializers import ValidationError
+from rest_framework import exceptions
 
 from authors.apps.authentication.models import User
 from authors.apps.authentication.serializers import (LoginSerializer,
                                                      RegistrationSerializer,
-                                                     UserSerializer)
+                                                     UserSerializer, 
+                                                     CreateEmailVerificationSerializer)
+
 
 
 class RegistrationSerializerTests(TestCase):
     """This class defines tests for the RegistrationSerializer class"""
+
     def setUp(self):
         self.user_data = {
             "username": "bob",
             "email": "bob@email.com",
-            "password": "hardpassword"
+            "password": "hardpassword",
+            "callback_url": "http://www.example.com"
         }
 
     def test_create_method(self):
@@ -27,6 +32,7 @@ class RegistrationSerializerTests(TestCase):
 
 class LoginSerializerTests(TestCase):
     """This class defines tests for the LoginSerializer class"""
+
     def test_validating_login_serializer_without_email(self):
         """Test if users can login without providing an email"""
         login_data = {"password": "hardpassword"}
@@ -64,6 +70,7 @@ class LoginSerializerTests(TestCase):
         login_data = {"email": "bob@email.com", "password": "hardpassword"}
         user = User.objects.create_user(username="bob", email="bob@email.com",
                                         password="hardpassword")
+        user.is_verified = True
         user.save()
         serializer = LoginSerializer(data=login_data)
 
@@ -75,13 +82,27 @@ class LoginSerializerTests(TestCase):
             returned_user_data
         )
 
+    def test_unverified_user_cannot_log_in(self):
+        """Users who have not verified their accounts should not be able to log in"""
+        login_data = {"email": "bob@email.com", "password": "hardpassword"}
+        user = User.objects.create_user(username="bob", email="bob@email.com",
+                                        password="hardpassword")
+        user.save()
+        serializer = LoginSerializer(data=login_data)
+
+        with self.assertRaises(ValidationError) as e:
+            serializer.validate(login_data)
+
+        self.assertEqual(e.exception.detail[0],
+                         "Please verify your account to proceed.")
+
 
 class UserSerializersTests(TestCase):
     """This class defines tests for the UserSerializer class"""
 
     def setUp(self):
         self.user = User.objects.create_user(username="bob", email="bob@email.com",
-                                        password="hardpassword")
+                                             password="hardpassword")
         self.user.save()
         self.serializer = UserSerializer()
 
@@ -103,3 +124,75 @@ class UserSerializersTests(TestCase):
         self.assertEqual(updated_user.username, "robert")
         self.assertEqual(updated_user.email, "robert@email.com")
         self.assertEqual(updated_user.password, user_password)
+
+
+class CreateEmailVerificationSerializerTests(TestCase):
+    """This class defines the tests for our CreateEmailVerificationSerializer"""
+
+    def test_user_must_pass_registered_email(self):
+        """
+        Users should only be able to get tokens when they send an email that has been registered
+        """
+
+        data = {'email': 'unregistered@mail.com', 'username': 'unregistered',
+                'callback_url': 'http://www.example.com'}
+        serializer = CreateEmailVerificationSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+
+        with self.assertRaises(ValidationError) as e:
+            serializer.create_payload(data)
+
+        self.assertEqual(e.exception.detail[0],
+                         "No user with this email address is registered.")
+
+    def test_user_must_pass_correct_email_address_and_username(self):
+        """The user must pass correct username and email in order to get a verification token"""
+
+        User.objects.create_user(username='real_user',
+                                 email='real@mail.com', password='password')
+
+        data = {'email': 'real@mail.com', 'username': 'unregistered',
+                'callback_url': 'http://www.example.com'}
+        serializer = CreateEmailVerificationSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+
+        with self.assertRaises(ValidationError) as e:
+            serializer.create_payload(data)
+
+        self.assertEqual(e.exception.detail[0],
+                         "Your username and email don't match.")
+
+    def test_serializer_returns_payload_when_user_passes_valid_data(self):
+        """
+        The serializer should return a payload containing 
+        the user data if the user provides valid data
+        """
+
+        User.objects.create_user(username='real_user',
+                                 email='real@mail.com', password='password')
+
+        data = {'email': 'real@mail.com', 'username': 'real_user',
+                'callback_url': 'http://www.example.com'}
+        serializer = CreateEmailVerificationSerializer(data=data)
+        self.assertTrue(serializer.is_valid())
+
+        output = serializer.create_payload(data)
+        self.assertEqual(output, data)
+        
+    def test_serializer_failure_because_verified_user_requests_token(self):
+        """Verified users should not be able to request new verification tokens"""
+
+        user = User.objects.create_user(username='test', email='test@mail.com', password='password')
+        user.is_verified = True
+        user.save()
+
+        data = {'email': 'test@mail.com',
+                'username': 'test',
+                'callback_url': 'http://www.example.com'}
+        
+        serializer = CreateEmailVerificationSerializer(data=data)
+        self.assertTrue(serializer.is_valid)
+
+        with self.assertRaises(exceptions.ValidationError) as e:
+            serializer.create_payload(data)
+        self.assertEqual(e.exception.detail[0], 'This user has already been verified')

--- a/authors/apps/authentication/tests/test_social_auth.py
+++ b/authors/apps/authentication/tests/test_social_auth.py
@@ -4,7 +4,6 @@ from rest_framework import status
 from rest_framework.test import APITestCase, APIClient
 
 
-
 class Test_Social_Authentication(APITestCase):
     """Tests social authentication"""
     url = reverse('authentication:social_login')

--- a/authors/apps/authentication/tests/test_user_registration.py
+++ b/authors/apps/authentication/tests/test_user_registration.py
@@ -11,14 +11,15 @@ class RegistrationTestCase(APITestCase):
         signup_data = {
             "user": {
                 "username": "Mary",
-                "email": "mary@gmail.com",
-                "password": "Mary1234"
+                "email": "yafyasufyi@desoz.com",
+                "password": "Mary1234",
+                "callback_url": "http://www.example.com"
             }
         }
 
         response = self.client.post(self.url, signup_data, format='json')
         signup_data_response = {
-            "email": "mary@gmail.com", "username": "Mary"
+            'message': 'Successfully created your account. Please proceed to your email yafyasufyi@desoz.com to verify your account.'
         }
         self.assertEqual(response.data, signup_data_response)
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
@@ -28,15 +29,17 @@ class RegistrationTestCase(APITestCase):
         blank_username_data = {
             "user": {
                 "username": "",
-                "email": "john@gmail.com",
-                "password": "John1234"
+                "email": "yafyasufyi@desoz.com",
+                "password": "Mary1234",
+                "callback_url": "http://www.example.com"
             }
         }
         blank_username_data_response = {"errors": {
             "username": ["Username field cannot be blank"]
         }
         }
-        response = self.client.post(self.url, blank_username_data, format='json')
+        response = self.client.post(
+            self.url, blank_username_data, format='json')
         self.assertEqual(response.data, blank_username_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -45,14 +48,16 @@ class RegistrationTestCase(APITestCase):
         no_username_field_data = {
             "user": {
                 "email": "john@gmail.com",
-                "password": "John1234"
+                "password": "John1234",
+                "callback_url": "http://www.youtube.com"
             }
         }
         no_username_field_data_response = {"errors": {
             "username": ["Username is required"]
         }
         }
-        response = self.client.post(self.url, no_username_field_data, format='json')
+        response = self.client.post(
+            self.url, no_username_field_data, format='json')
         self.assertEqual(response.data, no_username_field_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -62,14 +67,16 @@ class RegistrationTestCase(APITestCase):
             "user": {
                 "username": "Mary",
                 "email": "mary@gmail.com",
-                "password": "John1234"
+                "password": "John1234",
+                "callback_url": "http://www.youtube.com"
             }
         }
         existing_username_data = {
             "user": {
                 "username": "Mary",
                 "email": "maryg@gmail.com",
-                "password": "John1234"
+                "password": "John1234",
+                "callback_url": "http://www.youtube.com"
             }
         }
         existing_username_data_response = {"errors": {
@@ -77,7 +84,8 @@ class RegistrationTestCase(APITestCase):
         }
         }
         self.client.post(self.url, username_data, format='json')
-        response = self.client.post(self.url, existing_username_data, format='json')
+        response = self.client.post(
+            self.url, existing_username_data, format='json')
         self.assertEqual(response.data, existing_username_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -87,7 +95,8 @@ class RegistrationTestCase(APITestCase):
             "user": {
                 "username": "John",
                 "email": "",
-                "password": "John1234"
+                "password": "John1234",
+                "callback_url": "http://www.youtube.com"
             }
         }
         blank_email_data_response = {"errors": {
@@ -103,14 +112,16 @@ class RegistrationTestCase(APITestCase):
         no_email_field_data = {
             "user": {
                 "username": "John",
-                "password": "John1234"
+                "password": "John1234",
+                "callback_url": "http://www.example.com"
             }
         }
         no_email_field_data_response = {"errors": {
             "email": ["Email is required"]
         }
         }
-        response = self.client.post(self.url, no_email_field_data, format='json')
+        response = self.client.post(
+            self.url, no_email_field_data, format='json')
         self.assertEqual(response.data, no_email_field_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -120,7 +131,8 @@ class RegistrationTestCase(APITestCase):
             "user": {
                 "username": "John",
                 "email": "johngmail.com",
-                "password": "John1234"
+                "password": "John1234",
+                "callback_url": "http://www.youtube.com"
             }
         }
         invalid_email_data_response = {"errors": {
@@ -128,6 +140,7 @@ class RegistrationTestCase(APITestCase):
         }
         }
         response = self.client.post(self.url, invalid_email_data, format='json')
+
         self.assertEqual(response.data, invalid_email_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -137,14 +150,16 @@ class RegistrationTestCase(APITestCase):
             "user": {
                 "username": "John",
                 "email": "mary@gmail.com",
-                "password": "John1234"
+                "password": "John1234",
+                "callback_url": "http://www.youtube.com"
             }
         }
         existing_email_data = {
             "user": {
                 "username": "John Snow",
                 "email": "mary@gmail.com",
-                "password": "John1234"
+                "password": "John1234",
+                "callback_url": "http://www.youtube.com"
             }
         }
         existing_email_data_response = {"errors": {
@@ -152,7 +167,8 @@ class RegistrationTestCase(APITestCase):
         }
         }
         self.client.post(self.url, email_data, format='json')
-        response = self.client.post(self.url, existing_email_data, format='json')
+        response = self.client.post(
+            self.url, existing_email_data, format='json')
         self.assertEqual(response.data, existing_email_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -162,14 +178,16 @@ class RegistrationTestCase(APITestCase):
             "user": {
                 "username": "John",
                 "email": "john@gmail.com",
-                "password": ""
+                "password": "",
+                "callback_url": "http://www.youtube.com"
             }
         }
         blank_password_data_response = {"errors": {
             "password": ["Password field cannot be blank"]
         }
         }
-        response = self.client.post(self.url, blank_password_data, format='json')
+        response = self.client.post(
+            self.url, blank_password_data, format='json')
         self.assertEqual(response.data, blank_password_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -178,14 +196,16 @@ class RegistrationTestCase(APITestCase):
         no_password_field_data = {
             "user": {
                 "username": "John",
-                "email": "john@gmail.com"
+                "email": "john@gmail.com",
+                "callback_url": "http://www.youtube.com"
             }
         }
         no_password_field_data_response = {"errors": {
             "password": ["Password is required"]
         }
         }
-        response = self.client.post(self.url, no_password_field_data, format='json')
+        response = self.client.post(
+            self.url, no_password_field_data, format='json')
         self.assertEqual(response.data, no_password_field_data_response)
 
     def test_not_alphanumeric_password(self):
@@ -194,14 +214,16 @@ class RegistrationTestCase(APITestCase):
             "user": {
                 "username": "John",
                 "email": "john@gmail.com",
-                "password": "@John1234"
+                "password": "@John1234",
+                "callback_url": "http://www.youtube.com"
             }
         }
         not_alphanumeric_password_data_response = {"errors": {
             "password": ["Password should be alphanumeric"]
         }
         }
-        response = self.client.post(self.url, not_alphanumeric_password_data, format='json')
+        response = self.client.post(
+            self.url, not_alphanumeric_password_data, format='json')
         self.assertEqual(response.data, not_alphanumeric_password_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -211,14 +233,16 @@ class RegistrationTestCase(APITestCase):
             "user": {
                 "username": "Sally",
                 "email": "sally@gmail.com",
-                "password": "sally"
+                "password": "sally",
+                "callback_url": "http://www.youtube.com"
             }
         }
         not_alphanumeric_password_data_response = {"errors": {
             "password": ["Password should be at least 8 characters long"]
         }
         }
-        response = self.client.post(self.url, not_alphanumeric_password_data, format='json')
+        response = self.client.post(
+            self.url, not_alphanumeric_password_data, format='json')
         self.assertEqual(response.data, not_alphanumeric_password_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
@@ -228,13 +252,15 @@ class RegistrationTestCase(APITestCase):
             "user": {
                 "username": "Sally",
                 "email": "sally@gmail.com",
-                "password": 30 * "pellentesque"
+                "password": 30 * "pellentesque",
+                "callback_url": "http://www.youtube.com"
             }
         }
         not_alphanumeric_password_data_response = {"errors": {
             "password": ["Password should not be longer than 128 characters"]
         }
         }
-        response = self.client.post(self.url, not_alphanumeric_password_data, format='json')
+        response = self.client.post(
+            self.url, not_alphanumeric_password_data, format='json')
         self.assertEqual(response.data, not_alphanumeric_password_data_response)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/authors/apps/authentication/tests/test_views.py
+++ b/authors/apps/authentication/tests/test_views.py
@@ -1,78 +1,188 @@
+import json
+
 from django.test import TestCase
 from django.urls import reverse
+from django.conf import settings
 
 from rest_framework import status
 from rest_framework.test import APIClient, force_authenticate
 
+import jwt
+
+from authors.apps.authentication.models import User
+from authors.apps.core.utils import TokenHandler
+
+
 class RegistrationViewTest(TestCase):
     """This class defines tests for the RegistrationView class"""
+
     def setUp(self):
         self.user1 = {"user":
-                            {"email": "user1@mail.com",
-                            "username": "user1",
-                            "password": "password"}
-                    }
+                      {"email": "user1@mail.com",
+                       "username": "user1",
+                       "password": "password",
+                       "callback_url": "http://www.example.com"}
+                      }
 
     def test_user_can_register(self):
         """Test if a user is able to register"""
         client = APIClient()
-        response = client.post(reverse('authentication:register'), self.user1, format='json')
+        response = client.post(
+            reverse('authentication:register'), self.user1, format='json')
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
 
 class LoginViewTest(TestCase):
     """This class defines tests for the LoginView class"""
-    def setUp(self):
-        self.user1 = {"user":
-        {"email": "user1@mail.com",
-         "username": "user1",
-          "password": "password"}
-          }
-        self.user1_credentials = {"user": {
-            "email": "user1@mail.com",
-            "password": "password"
-        }}
 
     def test_registered_user_can_log_in(self):
         """Test if a registered user can log in"""
         client = APIClient()
-        client.post(reverse('authentication:register'), self.user1, format='json')
-        response = client.post(reverse('authentication:login'), self.user1_credentials, format='json')
+        user2 = User.objects.create_user(
+            username='user2', email='user2@mail.com', password='password')
+        user2.is_verified = True
+        user2.save()
+        response = client.post(reverse('authentication:login'), {
+                               'user': {'email': 'user2@mail.com', 'password': 'password'}}, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn('token', response.data)
+
 
 class UserRetrieveUpdateAPITest(TestCase):
     """This class defines tests for the UserRetrieveUpdateAPIView"""
+
+    def setUp(self):
+        self.verified_user = User.objects.create_user(
+            username='user1', email='verified@mail.com', password='password')
+        self.verified_user.is_verified = True
+        self.verified_user.save()
+        self.verified_data = {
+            'user': {'email': 'verified@mail.com', 'password': 'password'}}
+        self.client = APIClient()
+
     def test_if_we_can_retrieve_user_list(self):
         """Test if a logged in user can retrieve a user list"""
-        user1 = {"user":
-        {"email": "user1@mail.com",
-            "username": "user1",
-            "password": "password"}
-            }
-        client = APIClient()
-        client.post(reverse('authentication:register'), user1, format='json')
-        login_data = client.post(reverse('authentication:login'), {'user':{"email": "user1@mail.com", "password":"password"}}, format='json')
+
+        login_data = self.client.post(reverse('authentication:login'), {
+                                      'user': {"email": "verified@mail.com", "password": "password"}}, format='json')
         token = login_data.data['token']
         headers = {'HTTP_AUTHORIZATION': f'Bearer {token}'}
-        response = client.get(reverse('authentication:get users'), **headers)
+        response = self.client.get(
+            reverse('authentication:get users'), **headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_if_we_can_update_user_data(self):
         """Test if we can update the user data"""
-        user1 = {"user":
-        {"email": "user1@mail.com",
-            "username": "user1",
-            "password": "password"}
-            }
 
         update_info = {"user": {
             "email": "user1@mail.com",
             "bio": "I love to be tested",
             "values": "EPIC"
         }}
-        client = APIClient()
-        client.post(reverse('authentication:register'), user1, format='json')
-        login_data = client.post(reverse('authentication:login'), {'user':{"email": "user1@mail.com", "password":"password"}}, format='json')
+        login_data = self.client.post(reverse('authentication:login'), {
+                                      'user': {"email": "verified@mail.com", "password": "password"}}, format='json')
         token = login_data.data['token']
         headers = {'HTTP_AUTHORIZATION': f'Bearer {token}'}
-        response = client.put(reverse('authentication:get users'), **headers)
+        response = self.client.put(
+            reverse('authentication:get users'), **headers)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class EmailVerificationViewTest(TestCase):
+    """Test the email verification view"""
+
+    def test_verification_success_if_user_passes_valid_token(self):
+        """Users should be able to verify their account if they pass a valid token"""
+
+        byte_token = jwt.encode({
+            'data': 'fake',
+            'fake': 'data'
+        }, settings.SECRET_KEY, algorithm='HS256')
+        str_token = byte_token.decode('utf-8')
+        res = self.client.get(
+            reverse('authentication:verify email', args=(str_token,)))
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.data['error'], 'invalid token')
+
+    def test_verification_failure_if_nonexistent_user_tries_to_verify_account(self):
+        """Only registered users should be able to verify their email accounts"""
+
+        byte_token = jwt.encode({
+            'email': 'fake@mail.com',
+            'username': 'user'
+        }, settings.SECRET_KEY, algorithm='HS256')
+        str_token = byte_token.decode('utf-8')
+        res = self.client.get(
+            reverse('authentication:verify email', args=(str_token,)))
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(res.data['email'],
+                         'No user with this email has been registered')
+
+    def test_verified_users_cannot_verify_their_email_again(self):
+        """Users who are verified should not be able to request for verification tokens"""
+
+        registered_user = User.objects.create_user(
+            username='user', email='user@mail.com', password='password')
+        registered_user.is_verified = True
+        registered_user.save()
+
+        data = {
+            'username': 'user',
+            'email': 'user@mail.com'
+        }
+
+        byte_token = jwt.encode({
+            'username': data['username'],
+            'email': data['email']
+        }, settings.SECRET_KEY, algorithm='HS256')
+        str_token = byte_token.decode('utf-8')
+
+        client = APIClient()
+        res = client.get(
+            reverse('authentication:verify email', args=(str_token,)))
+        self.assertEqual(res.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(res.data['email'],
+                         'This email has already been verified')
+
+    def test_users_can_get_verified(self):
+        """Unverified users should be able to verify their accounts"""
+        user = User.objects.create_user(username='blazer', email='blazer@test.com', password='password')
+        user.save()
+
+        data = {'email': 'blazer@test.com',
+                'username': 'blazer',
+                'callback_url': 'http://www.youtube.com'}
+
+        token = TokenHandler().create_verification_token(data)
+
+        client = APIClient()
+        res = client.get(reverse('authentication:verify email', args=(token,)))
+        self.assertEqual(res.status_code, status.HTTP_302_FOUND)
+
+
+class CreateEmailVerificationTokenAPIViewTest(TestCase):
+    """Here we test if new verification tokens are created"""
+
+    def setUp(self):
+
+        self.registered_user = User.objects.create_user(
+            username='registered', email='reg@mail.com', password='password')
+        self.registered_user.save()
+        self.data = {
+            "email": "reg@mail.com",
+            "username": "registered",
+            "callback_url": "http://www.example.com"
+        }
+
+    def test_email_is_sent_to_user(self):
+        """We assert that an email can be sent to the user"""
+
+        client = APIClient()
+        res = client.post(
+            reverse('authentication:new verification token'), self.data, format='json')
+
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(
+            res.data['message'], 'New verification token created. Please proceed to your email reg@mail.com to verify your account.')
+
+

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
 
 from .views import (LoginAPIView, RegistrationAPIView,
-                    UserRetrieveUpdateAPIView, SocialAuthenticationView)
+                    UserRetrieveUpdateAPIView, SocialAuthenticationView,
+                    EmailVerificationView, CreateEmailVerificationTokenAPIView)
 
 app_name = 'authentication'
 
@@ -10,6 +11,11 @@ urlpatterns = [
     path('users/', RegistrationAPIView.as_view(), name='register'),
     path('users/login/', LoginAPIView.as_view(), name='login'),
     path('users/oauth/', SocialAuthenticationView.as_view(),
-         name='social_login')
+         name='social_login'),
+    path(
+        'activate/<str:token>',
+        EmailVerificationView.as_view(), name='verify email'),
+    path('token/', CreateEmailVerificationTokenAPIView.as_view(),
+         name='new verification token'),
 
 ]

--- a/authors/apps/core/tests/test_utils.py
+++ b/authors/apps/core/tests/test_utils.py
@@ -1,0 +1,71 @@
+from datetime import date, timedelta
+
+from django.test import TestCase
+from django.conf import settings
+from rest_framework import exceptions
+
+import jwt
+
+from authors.apps.core.utils import TokenHandler
+
+
+class TestTokenHandler(TestCase):
+    """Test if TokenHandler returns tokens as expected"""
+
+    def test_token_is_created(self):
+        """We test whether we are able to create a token"""
+
+        payload = {
+            'email': 'test@mail.com',
+            'callback_url': 'http://www.example.com'
+        }
+
+        token = TokenHandler().create_verification_token(payload)
+        # a valid token should be decoded
+        self.assertTrue(TokenHandler().validate_token(token))
+
+    def test_decoding_failure_because_payload_is_not_dictionary(self):
+        """The payload to be encoded should be a dictionary"""
+
+        payload = ['just a list']
+
+        with self.assertRaises(TypeError) as e:
+            TokenHandler().create_verification_token(payload)
+        self.assertEqual(str(e.exception), 'Payload must be a dictionary!')
+
+    def test_token_can_only_be_encoded_if_neccessary_keys_are_passed(self):
+        """For a token to be created, we need the `email` and `callback_url` to be provided"""
+
+        error = TokenHandler().create_verification_token({})
+        self.assertEqual(error, 'Please provide email and callback_url')
+
+    def test_expired_token_results_in_an_error(self):
+        """If a token expires, users should not be verified by providing it"""
+
+        token_expiry = date.today() - timedelta(1)
+
+        payload = {
+            'email': 'test@mail.com',
+            'callback_url': 'http://www.example.com'
+        }
+
+        token = jwt.encode({
+            'email': payload['email'],
+            'callback_url': payload['callback_url'],
+            'exp': int(token_expiry.strftime('%s'))
+        },
+            settings.SECRET_KEY, algorithm='HS256')
+
+        with self.assertRaises(exceptions.AuthenticationFailed) as e:
+            TokenHandler().validate_token(token)
+
+        self.assertEqual(
+            str(e.exception), 'Your token has expired. Make a new token and try again')
+
+    def test_an_invalid_token_cannot_be_decoded(self):
+        """If a user passes an invalid jwt token, it should not be decoded"""
+
+        token = ''
+        res = TokenHandler().validate_token(token)
+
+        self.assertEqual(res, 'Error. Could not decode token!')

--- a/authors/apps/core/utils.py
+++ b/authors/apps/core/utils.py
@@ -1,0 +1,55 @@
+from datetime import datetime, timedelta
+
+import jwt
+
+from django.conf import settings
+
+from rest_framework import exceptions
+
+
+class TokenHandler:
+    """This class contains the methods for creating custom
+    tokens for users"""
+
+    def create_verification_token(self, payload):
+        """
+        Create a JWT token to be sent in the verification
+        email url
+        """
+
+        if not isinstance(payload, dict):
+            raise TypeError('Payload must be a dictionary!')
+
+        token_expiry = datetime.now() + timedelta(hours=12)
+
+        try:
+            token = jwt.encode({
+                'email': payload['email'],
+                'callback_url': payload['callback_url'],
+                'exp': int(token_expiry.strftime('%s'))},
+                settings.SECRET_KEY, algorithm='HS256')
+            return token.decode('utf-8')
+
+        except KeyError:
+            return "Please provide email and callback_url"
+
+    def validate_token(self, token):
+        """
+        Validate provided token. The email encoded in the token
+        should be equal to the email of the user instance being
+        passed.
+        """
+
+        try:
+            decoded_token = jwt.decode(
+                token, settings.SECRET_KEY, algorithm='HS256')
+
+        except jwt.exceptions.ExpiredSignatureError:
+            msg = 'Your token has expired. Make a new token and try again'
+            raise exceptions.AuthenticationFailed(msg)
+
+        except Exception:
+            msg = 'Error. Could not decode token!'
+            return msg
+
+        return decoded_token

--- a/authors/apps/profiles/tests/test_views.py
+++ b/authors/apps/profiles/tests/test_views.py
@@ -27,6 +27,7 @@ class TestProfileViews(TestCase):
                 'username': self.username,
                 'email': self.email,
                 'password': self.password,
+                'callback_url': 'http://www.example.com'
             }
         }
         self.updated_data = {
@@ -41,12 +42,11 @@ class TestProfileViews(TestCase):
             "website": "notavalidurlforawebsiteman"
         }
         self.image_link = {
-            "image":"cats.jpg"
+            "image": "cats.jpg"
         }
         self.bad_image_link = {
-            "image":"cats.pdf"
+            "image": "cats.pdf"
         }
-
 
         self.test_client = Client()
 
@@ -132,7 +132,7 @@ class TestProfileViews(TestCase):
 
         self.assertEqual(response.json()['errors']['profile']['website'], [
                          "Enter a valid URL."])
-    
+
     def test_if_image_uploads_successfully(self):
         """ test if an profile image uploads successfully """
         token = self.login_a_user()
@@ -143,7 +143,7 @@ class TestProfileViews(TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.json()['user']['profile']['image_url'],
-            "https://res.cloudinary.com/dbsri2qtr/image/upload/c_fill,h_150,w_100/cats")
+                         "https://res.cloudinary.com/dbsri2qtr/image/upload/c_fill,h_150,w_100/cats")
 
     def test_if_one_can_upload_pdf_as_profile_image(self):
         """ test if an profile image uploads successfully """
@@ -155,4 +155,4 @@ class TestProfileViews(TestCase):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json()['user']['image'],
-            "Only '.png', '.jpg', '.jpeg' files are accepted")
+                         "Only '.png', '.jpg', '.jpeg' files are accepted")

--- a/authors/settings/base.py
+++ b/authors/settings/base.py
@@ -76,6 +76,7 @@ TEMPLATES = [
                 'django.contrib.messages.context_processors.messages',
                 'social_django.context_processors.backends',
                 'social_django.context_processors.login_redirect',
+                'django.core.context_processors.request',
             ],
         },
     },

--- a/authors/settings/dev.py
+++ b/authors/settings/dev.py
@@ -16,3 +16,11 @@ DATABASES = {
         'PORT': '',
     }
 }
+
+DOMAIN = config('DOMAIN', default='')
+EMAIL_HOST = config('EMAIL_HOST', default='localhost')
+EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')
+EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
+EMAIL_PORT = config('EMAIL_PORT', default=587, cast=int)
+EMAIL_USE_TLS = config('EMAIL_USE_TLS', default=True, cast=bool)
+FROM_EMAIL = config('EMAIL_FROM', default='verify@authorsheaven.com')

--- a/authors/settings/prod.py
+++ b/authors/settings/prod.py
@@ -17,3 +17,10 @@ DATABASES = {
         default=config('DATABASE_URL')
     )
 }
+
+EMAIL_HOST = config('EMAIL_HOST', default='')
+EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')
+EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
+EMAIL_PORT = config('EMAIL_PORT', default=587, cast=int)
+EMAIL_USE_TLS = config('EMAIL_USE_TLS', default=True, cast=bool)
+FROM_EMAIL = config('EMAIL_FROM', default='test@example.com')

--- a/authors/settings/test.py
+++ b/authors/settings/test.py
@@ -15,3 +15,7 @@ DATABASES = {
         'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
     }
 }
+
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+DOMAIN = '127.0.0.1:8000/'
+FROM_EMAIL = 'test@test.com'

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,7 +32,6 @@ mccabe==0.6.1
 mock==2.0.0
 pbr==5.1.3
 oauthlib==3.0.1
-psycopg2==2.7.7
 psycopg2-binary==2.7.7
 pycodestyle==2.5.0
 pyflakes==2.1.0
@@ -53,3 +52,7 @@ uritemplate==3.0.0
 urllib3==1.24.1
 whitenoise==4.1.2
 wrapt==1.11.1
+coreapi==2.3.3
+drf-yasg==1.13.0
+sendgrid==5.6.0
+python-http-client==3.1.0


### PR DESCRIPTION
#### Description
Whenever users create an account, it is good practice to have them verify their email addresses so we can be sure that the users are indeed real and that they own the accounts they used for registration. This feature implements email verification by sending a JWT token to the user email address that should be decoded. If the token is valid, the token is decoded and the user is redirected to a callback URL that they provided when registering.
#### Type of change
- [x] Breaking Change(Users must provide a callback url when registering, Unverified users cannot log in )
- [x] Non-breaking changes ( Users can get a new verification token if the old one expires, Users can verify their accounts via email)

#### How Has This Been Tested?
- [x] Unit Tests
- [x] Integration Tests

#### Checklist:
- [x] I have tested all new functions
- [x] Feature passes team flake8 standards
- [x] Refactored prior tests to make them pass considering I have breaking changes

### How can this be manually tested?
- Follow instructions on the README page and set up your environment locally.
- Check out to this branch `ft-email-verification-164046247` and install requirements by running `pip install -r requirements.txt`
- Register a user using a valid email address, and be sure to add a callback URL. It can be any URL of your choice. Here is an example:
 ```
{"user": {
"username": "cray",
"email": "cray@mail.com",
"password": "password",
"callback_url": "http://www.youtube.com"}}
```

- You should get a response that you check your email address for a verification link. Copy and paste that link in your browser and you should be redirected to the callback url you provided. Verified users should not be able to verify again, and users should only be able to verify their own email addresses.
- To get a new verification token, navigate to the endpoint `/api/token/` and pass in your username and email. If you pass in incorrect information, you should not be able to get a reset token. Only registered users can get a reset token. To verifiy the token, simply go to your email address and copy and paste the link in your browser. You should be redirected to the callback URL you provided

#### PT
[#164046247](https://www.pivotaltracker.com/story/show/164046247)