### PR TITLE
[#164046248] Users can reset their password

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,46 @@ Authentication required, returns the User
 
 Accepted fields: `email`, `username`, `password`, `image`, `bio`
 
+### Reset Password
+
+`POST /api/users/password-reset/`
+
+Example request body:
+
+```source-json
+{
+            "payload": {
+                "email": "jake@jake.com",
+                "callback_url": "https://legion.com"
+
+            }
+        }
+```
+
+Requires a registered user, returns a message, sends an email to given address
+
+Accepted fields: `email`, `callback_url`
+
+
+`PUT /api/users/password-reset/`
+
+Example request body:
+
+```source-json
+{
+  "user_password":{
+    "password": "jake123son",
+    "confirm_password": "jake123son",
+    "token":"valid-token"
+  }
+}
+```
+
+Requires a registered user and a token contained in the link sent to the supplied email address, returns a message
+
+Accepted fields: `password`, `new_password`, `token`
+
+
 ### Get Profile
 
 `GET /api/profiles/:username`

--- a/authors/apps/authentication/models.py
+++ b/authors/apps/authentication/models.py
@@ -145,3 +145,16 @@ class User(AbstractBaseUser, PermissionsMixin):
         }, settings.SECRET_KEY, algorithm='HS256')
 
         return token.decode('utf-8')
+
+
+class PasswordResetToken(models.Model):
+    """This class creates a Password Reset Token model."""
+
+    user = models.ForeignKey(
+        User,
+        related_name='password_reset_token',
+        on_delete=models.CASCADE
+    )
+    token = models.TextField()
+    created = models.DateTimeField(auto_now=True)
+    is_valid = models.BooleanField(default=True)

--- a/authors/apps/authentication/templates/password_reset.html
+++ b/authors/apps/authentication/templates/password_reset.html
@@ -1,0 +1,92 @@
+<!doctype html>
+
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+
+  <title>Password Reset</title>
+  <meta name="description" content="Password Reset">
+  <meta name="author" content="Legion">
+
+</head>
+
+<body style="
+background: #D9DDDC;
+  	color: #333;
+  	font: 16px Arial;
+">
+	<div class=container style="
+    background: #FFFFFF;
+  	padding:20px 50px;
+  	width: 40%;
+  	margin: 10px auto;
+">
+<div class=header style="
+  	color: #837E7C;
+  	font: 18px Arial Narrow;
+">
+	<p>Author's Haven</p>
+	<hr style="
+  	background: #EFEFEF;
+  	border: #EFEFEF;
+  	height: 1px;
+">
+</div>
+<div class="content">
+	<p style="
+	margin-bottom: 40px;
+	">
+	Someone (hopefully you) has requested a password reset for your Author's haven account.
+		Click the button below to set a new password:
+
+	</p>
+	<a href="{{callback_url}}/{{token}}/"><button style ="
+display: inline-block;
+    border: none;
+    padding: 1rem 2rem;
+    margin: 0;
+    text-decoration: none;
+    background: #0069ed;
+    color: #ffffff;
+    font-family: sans-serif;
+    font-size: 1rem;
+    cursor: pointer;
+    text-align: center;
+    transition: background 250ms ease-in-out,
+                transform 150ms ease;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+">Reset Password</button></a>
+
+	<p style="
+	margin: 40px 0 60px 0;
+	">
+	If you don't wish to reset your password, disregard this email and no action will be taken.
+
+	</p>
+	<p style="
+	margin-bottom: 40px;
+	">
+	The Authors Haven team.
+
+	</p>
+</div>
+	<hr style="
+  	background: #EFEFEF;
+  	border: #EFEFEF;
+  	height: 1px;
+">
+<div class="footer" style="
+  	color: #837E7C;
+  	font: 14px Arial Narrow;
+">
+	<p style="
+	margin-bottom: 40px;
+	">
+Authors Haven ia a social platform for the creative at heart whose vision is to
+create a community of like minded authors to foster inspiration and innovation by leveraging the modern web.
+	</p>
+</div>
+</div>
+</body>
+</html>

--- a/authors/apps/authentication/tests/test_jwt.py
+++ b/authors/apps/authentication/tests/test_jwt.py
@@ -57,7 +57,8 @@ class JWTAuthenticationTest(TestCase):
             res.data['detail'], 'Invalid token provided. Authentication failure.')
 
     def test_failure_if_user_does_not_exist(self):
-        """We register a user to get the token, then delete the user from the database. When a user tries to pass the token to access the endpoint, they should be forbidden from proceeding."""
+        """We register a user to get the token, then delete the user from the database.
+        When a user tries to pass the token to access the endpoint, they should be forbidden from proceeding."""
         test_user = User.objects.create(
             username='test_user', email='test_user@mail.com', password='password')
         test_token = test_user.token

--- a/authors/apps/authentication/tests/test_password_reset.py
+++ b/authors/apps/authentication/tests/test_password_reset.py
@@ -1,0 +1,391 @@
+from datetime import datetime, timedelta
+import jwt
+from django.conf import settings
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.generics import get_object_or_404
+from rest_framework.test import APITestCase
+from authors.apps.authentication.serializers import PasswordResetTokenSerializer
+from authors.apps.core.utils import TokenHandler
+from authors.apps.authentication.models import User, PasswordResetToken
+
+
+class PasswordResetTestCase(APITestCase):
+    """Tests for password reset functionality."""
+    register_url = reverse('authentication:register')
+    url = reverse('authentication:password-reset')
+
+    def test_valid_request(self):
+        """Tests for a valid request for a password reset link."""
+        signup_data = {
+            "user": {
+                "username": "Mary",
+                "email": "mary@gmail.com",
+                "password": "Mary1234",
+                "callback_url": "https://medium.com"
+            }
+        }
+
+        payload = {
+            "payload": {
+                "email": "mary@gmail.com",
+                "callback_url": "https://medium.com"
+
+            }
+        }
+
+        valid_request_response = {"message":
+                                  "A password reset link has been sent to your "
+                                  "email."
+}
+        self.client.post(self.register_url, signup_data, format='json')
+        response = self.client.post(self.url, payload, format='json')
+        self.assertEqual(response.data, valid_request_response)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_not_registered_email(self):
+        """Tests for a request with an unregistered user email."""
+        payload = {
+            "payload": {
+                "email": "maryperry@gmail.com",
+                "callback_url": "https://medium.com"
+
+            }
+        }
+
+        valid_request_response = {"message":
+                                  "A password reset link has been sent to your "
+                                  "email."
+                                  }
+
+        response = self.client.post(self.url, payload, format='json')
+        self.assertEqual(response.data, valid_request_response)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_valid_new_password(self):
+        """Tests for a request with a valid new password."""
+        signup_data = {
+            "user": {
+                "username": "Mary",
+                "email": "mary@gmail.com",
+                "password": "Mary1234",
+                "callback_url": "https://medium.com"
+            }
+        }
+
+        payload = {
+                "email": "mary@gmail.com",
+                "callback_url": "https://medium.com"
+
+            }
+        token = TokenHandler().create_verification_token(payload)
+
+        data = {
+            "user_password": {
+                "password": "mary1234",
+                "confirm_password": "mary1234",
+                "token": token
+            }
+        }
+        self.client.post(self.register_url, signup_data, format='json')
+        user = get_object_or_404(User, email="mary@gmail.com")
+        user_id = user.id
+        token_data = {
+            "user": user_id,
+            "token": token
+        }
+        serializer = PasswordResetTokenSerializer(data=token_data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        data_response = {"message": "Your password has been changed."}
+        response = self.client.put(self.url, data, format='json')
+        self.assertEqual(response.data, data_response)
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+
+    def test_invalid_token(self):
+        """Tests for a request with an invalid token."""
+        signup_data = {
+            "user": {
+                "username": "Mary",
+                "email": "mary@gmail.com",
+                "password": "Mary1234",
+                "callback_url": "https://medium.com"
+            }
+        }
+        token_expiry = datetime.now() + timedelta(hours=12)
+        token = jwt.encode({
+            'email': "mary123@gmail.com",
+            'callback_url': "https://medium.com",
+            'exp': int(token_expiry.strftime('%s'))},
+            settings.SECRET_KEY, algorithm='HS256')
+
+        invalid_token = token.decode('utf-8')
+
+        data = {
+            "user_password": {
+                "password": "mary1234",
+                "confirm_password": "mary1234",
+                "token": invalid_token
+            }
+        }
+
+        data_response = {'message': 'A user with the given token does not exist.'}
+        self.client.post(self.register_url, signup_data, format='json')
+        response = self.client.put(self.url, data, format='json')
+        self.assertEqual(response.data, data_response)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_using_same_link_twice(self):
+        """Tests for a request with an already used token."""
+        signup_data = {
+            "user": {
+                "username": "Mary",
+                "email": "mary@gmail.com",
+                "password": "Mary1234",
+                "callback_url": "https://medium.com"
+            }
+        }
+        payload = {
+            "email": "mary@gmail.com",
+            "callback_url": "https://medium.com"
+
+        }
+
+        token = TokenHandler().create_verification_token(payload)
+
+        data = {
+            "user_password": {
+                "password": "mary1234",
+                "confirm_password": "mary1234",
+                "token": token
+            }
+        }
+
+        data_response = {"message": "Sorry, we couldn't find that password reset key in our database."
+                                    " Please send another request."}
+
+        self.client.post(self.register_url, signup_data, format='json')
+        user = get_object_or_404(User, email="mary@gmail.com")
+        user_id = user.id
+        token_data = {
+            "user": user_id,
+            "token": token
+        }
+        serializer = PasswordResetTokenSerializer(data=token_data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        self.client.post(self.register_url, signup_data, format='json')
+        self.client.put(self.url, data, format='json')
+        response = self.client.put(self.url, data, format='json')
+        self.assertEqual(response.data, data_response)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_blank_password(self):
+        """Tests for a request with a blank password."""
+        signup_data = {
+            "user": {
+                "username": "Mary Jane",
+                "email": "maryjane@gmail.com",
+                "password": "Mary1234",
+                "callback_url": "https://medium.com"
+            }
+        }
+        payload = {
+                "email": "maryjane@gmail.com",
+                "callback_url": "https://www.youtube.com/"
+
+            }
+
+        token = TokenHandler().create_verification_token(payload)
+        blank_password_data = {
+            "user_password": {
+                "password": "",
+                "confirm_password": "",
+                "token": token
+            }
+        }
+
+        blank_password_data_response = {"errors": {
+            "password": ["Password field cannot be blank"]
+        }
+        }
+        self.client.post(self.register_url, signup_data, format='json')
+        response = self.client.put(self.url, blank_password_data, format='json')
+        self.assertEqual(response.data, blank_password_data_response)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_no_password_field(self):
+        """Tests for a request with no password field."""
+        signup_data = {
+            "user": {
+                "username": "Mary Jane",
+                "email": "maryjane@gmail.com",
+                "password": "Mary1234",
+                "callback_url": "https://medium.com"
+            }
+        }
+        payload = {
+            "email": "maryjane@gmail.com",
+            "callback_url": "https://www.youtube.com/"
+
+        }
+        token = TokenHandler().create_verification_token(payload)
+        blank_password_data = {
+            "user_password": {
+                "password": "",
+                "confirm_password": "",
+                "token": token
+            }
+        }
+
+        blank_password_data_response = {"errors": {
+            "password": ["Password field cannot be blank"]
+        }
+        }
+        self.client.post(self.register_url, signup_data, format='json')
+        response = self.client.put(self.url, blank_password_data, format='json')
+        self.assertEqual(response.data, blank_password_data_response)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_not_alphanumeric_password(self):
+        """"Tests for a request with a password that is not alphanumeric."""
+        signup_data = {
+            "user": {
+                "username": "Mary Jane",
+                "email": "maryjane@gmail.com",
+                "password": "Mary1234",
+                "callback_url": "https://medium.com"
+            }
+        }
+        payload = {
+            "email": "maryjane@gmail.com",
+            "callback_url": "https://www.youtube.com/"
+
+        }
+        token = TokenHandler().create_verification_token(payload)
+        not_alphanumeric_password_data = {
+            "user_password": {
+                "password": "@343212#@!",
+                "confirm_password": "@343212#@!",
+                "token": token
+            }
+        }
+
+        not_alphanumeric_password_data_response = {"errors": {
+            "password": ["Password should be alphanumeric"]
+        }
+        }
+        self.client.post(self.register_url, signup_data, format='json')
+        response = self.client.put(self.url, not_alphanumeric_password_data, format='json')
+        self.assertEqual(response.data, not_alphanumeric_password_data_response)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_short_password(self):
+        """"Tests for a request with a password shorter than 8 characters."""
+        signup_data = {
+            "user": {
+                "username": "Mary Jane",
+                "email": "maryjane@gmail.com",
+                "password": "Mary1234",
+                "callback_url": "https://medium.com"
+            }
+        }
+        payload = {
+            "email": "maryjane@gmail.com",
+            "callback_url": "https://www.youtube.com/"
+
+        }
+        token = TokenHandler().create_verification_token(payload)
+        short_password_data = {
+            "user_password": {
+                "password": "try",
+                "confirm_password": "try",
+                "token": token
+            }
+        }
+
+        short_password_data_response = {"errors": {
+            "password": ["Password should be at least 8 characters long"]
+        }
+        }
+        self.client.post(self.register_url, signup_data, format='json')
+        response = self.client.put(self.url, short_password_data,
+                                   format='json')
+        self.assertEqual(response.data, short_password_data_response)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_long_password(self):
+        """"Tests for a request with a password longer than 128 characters."""
+        signup_data = {
+            "user": {
+                "username": "Mary Jane",
+                "email": "maryjane@gmail.com",
+                "password": "Mary1234",
+                "callback_url": "https://medium.com"
+            }
+        }
+        payload = {
+            "email": "maryjane@gmail.com",
+            "callback_url": "https://www.youtube.com/"
+
+        }
+        token = TokenHandler().create_verification_token(payload)
+        long_password_data = {
+            "user_password": {
+                "password": "try"*50,
+                "confirm_password": "try"*50,
+                "token": token
+            }
+        }
+
+        long_password_data_response = {"errors": {
+            "password": ["Password should not be longer than 128 characters"]
+        }
+        }
+        self.client.post(self.register_url, signup_data, format='json')
+        response = self.client.put(self.url, long_password_data,
+                                   format='json')
+        self.assertEqual(response.data, long_password_data_response)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_not_matching_passwords(self):
+        """"Tests for a request with passwords that do not match."""
+        signup_data = {
+            "user": {
+                "username": "Mary Jane",
+                "email": "maryjane@gmail.com",
+                "password": "Mary1234",
+                "callback_url": "https://medium.com"
+            }
+        }
+        payload = {
+            "email": "maryjane@gmail.com",
+            "callback_url": "https://www.youtube.com/"
+
+        }
+        token = TokenHandler().create_verification_token(payload)
+        password_data = {
+            "user_password": {
+                "password": "try12qw3ew45r",
+                "confirm_password": "trytrfds234erwdsq",
+                "token": token
+            }
+        }
+
+        self.client.post(self.register_url, signup_data, format='json')
+        user = get_object_or_404(User, email="maryjane@gmail.com")
+        user_id = user.id
+        token_data = {
+            "user": user_id,
+            "token": token
+        }
+        serializer = PasswordResetTokenSerializer(data=token_data)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        password_data_response = {"message": "Passwords do not Match"}
+        response = self.client.put(self.url, password_data,
+                                   format='json')
+        self.assertEqual(response.data, password_data_response)

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -2,7 +2,8 @@ from django.urls import path
 
 from .views import (LoginAPIView, RegistrationAPIView,
                     UserRetrieveUpdateAPIView, SocialAuthenticationView,
-                    EmailVerificationView, CreateEmailVerificationTokenAPIView)
+                    EmailVerificationView, CreateEmailVerificationTokenAPIView,
+                    PasswordResetView)
 
 app_name = 'authentication'
 
@@ -17,5 +18,8 @@ urlpatterns = [
         EmailVerificationView.as_view(), name='verify email'),
     path('token/', CreateEmailVerificationTokenAPIView.as_view(),
          name='new verification token'),
+    path('users/password-reset/', PasswordResetView.as_view(),
+         name='password-reset')
+
 
 ]

--- a/authors/apps/core/utils.py
+++ b/authors/apps/core/utils.py
@@ -6,6 +6,9 @@ from django.conf import settings
 
 from rest_framework import exceptions
 
+from django.core.mail import EmailMessage
+from django.template.loader import render_to_string
+
 
 class TokenHandler:
     """This class contains the methods for creating custom
@@ -53,3 +56,15 @@ class TokenHandler:
             return msg
 
         return decoded_token
+
+    def send_password_reset_link(self, to_email, token, callback_url):
+        domain = settings.DOMAIN
+        html_content = render_to_string('password_reset.html',
+                                        {'callback_url': callback_url,
+                                         'token': token, 'domain': domain})
+        subject = 'Reset your Author\'s Haven Password'
+        from_email = settings.EMAIL_HOST_USER
+        msg = EmailMessage(subject, html_content, from_email, [to_email])
+        msg.content_subtype = 'html'
+        msg.send()
+

--- a/authors/settings/dev.py
+++ b/authors/settings/dev.py
@@ -16,3 +16,12 @@ DATABASES = {
         'PORT': '',
     }
 }
+
+SENDGRID_API_KEY = config('SENDGRID_API_KEY', default='')
+DOMAIN = config('DOMAIN', default='')
+EMAIL_HOST = config('EMAIL_HOST', default='localhost')
+EMAIL_HOST_USER = config('EMAIL_HOST_USER', default='')
+EMAIL_HOST_PASSWORD = config('EMAIL_HOST_PASSWORD', default='')
+EMAIL_PORT = config('EMAIL_PORT')
+EMAIL_USE_TLS = config('EMAIL_USE_TLS')
+FROM_EMAIL = config('EMAIL_FROM', default='verify@authorsheaven.com')

--- a/authors/settings/test.py
+++ b/authors/settings/test.py
@@ -17,5 +17,6 @@ DATABASES = {
 }
 
 EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
-DOMAIN = '127.0.0.1:8000/'
 FROM_EMAIL = 'test@test.com'
+DOMAIN = config('DOMAIN', default='')
+


### PR DESCRIPTION
### Description
Adds password reset functionality which is valuable in instances where users forget their login credentials.

### Type of change
- [x] Non-breaking change (Users can reset their passwords).

### How Has This Been Tested
- [x] Integration test
- [x] End to end

### Checklist
- [x] Feature passes team's flake8 standards
- [x] New and existing unit tests pass locally with my changes

### How can this be manually tested?
The two endpoints require a registered user. A user supplies their registered email address and a callback URL which is the domain of the application. A  link containing the token is sent to the supplied email address. On clicking the link, a user is redirected to the page contained in the call back URL where they will reset their password. Here they supply a password and a confirm password. This is then updated.
`POST /api/users/password-reset/`

Example request body:

```source-json
{
            "payload": {
                "email": "jake@jake.com",
                "callback_url": "https://legion.com"
            }
        }
```
`PUT /api/users/password-reset/`

Example request body:

```source-json
{
  "user_password":{
    "password": "jake123son",
    "confirm_password": "jake123son",
   "token": "valid-token"
  }
}
```
#### PT
[#164046248](https://www.pivotaltracker.com/story/show/164046248)
