### PR TITLE
#164046255 Users can like, dislike or unlike articles

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -48,3 +48,12 @@ class Article(models.Model):
 
     class Meta:
         ordering = ["-created_at", "-updated_at"]
+
+
+class Like(models.Model):
+    user_id = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE,
+        related_name='likes')
+    article_id = models.ForeignKey(
+        Article, on_delete=models.CASCADE, related_name='likes')
+    is_like = models.BooleanField()

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,5 +1,5 @@
 from rest_framework import serializers
-from .models import Article
+from .models import Article, Like
 
 
 class TheArticleSerializer(serializers.ModelSerializer):
@@ -43,3 +43,12 @@ class TheArticleSerializer(serializers.ModelSerializer):
         instance.save()
         return instance
 
+
+class LikesSerializer(serializers.ModelSerializer):
+    """
+    Serializers for likes
+    """
+    class Meta():
+        model = Like
+        fields = ('id', 'user_id', 'article_id', 'is_like')
+        read_only_fields = ['id']

--- a/authors/apps/articles/tests/article_tests_base_class.py
+++ b/authors/apps/articles/tests/article_tests_base_class.py
@@ -1,0 +1,46 @@
+from rest_framework.test import APITestCase, APIClient
+from django.urls import reverse
+from .test_data import *
+from authors.apps.authentication.models import User
+from authors.apps.articles.models import Article
+
+
+class ArticlesBaseTest(APITestCase):
+    """Sets up tests for features related to articles"""
+
+    def setUp(self):
+        client = APIClient()
+        self.user1 = User.objects.create_user(
+            username='Moracha', email="jratcher@gmail.com", password='password')
+        self.user1.is_verified = True
+        self.user1.save()
+        self.user2 = User.objects.create_user(
+            username='Josh', email='joshmoracha@gmail.com', password='password')
+        self.user2.is_verified = True
+        self.user2.save()
+        self.user1_credentials = client.post(reverse('authentication:login'),
+                                             user1, format='json')
+        self.user2_credentials = client.post(reverse('authentication:login'),
+                                             user2, format='json')
+        user1_token = self.user1_credentials.data.get('token')
+        user2_token = self.user2_credentials.data.get('token')
+        self.header_user1 = {
+            'HTTP_AUTHORIZATION': f'Bearer {user1_token}'
+        }
+        self.header_user2 = {
+            'HTTP_AUTHORIZATION': f'Bearer {user2_token}'
+        }
+        response = client.post(reverse('articles:create_article'),
+                               article, **self.header_user1, format='json')
+       
+        self.slug = response.data.get('slug')
+        #Publish article
+        retrieved_article = Article.objects.filter(slug=self.slug).first()
+        retrieved_article.published = True
+        retrieved_article.save()
+        self.like_article_url = '/api/articles/{}/like/'.format(self.slug)
+
+
+
+
+

--- a/authors/apps/articles/tests/test_data.py
+++ b/authors/apps/articles/tests/test_data.py
@@ -1,0 +1,29 @@
+user2 = {
+    "user": {
+        "username": "Josh",
+        "email": "joshmoracha@gmail.com",
+        "password": "password",
+        'callback_url': 'http://www.youtube.com'
+    }
+}
+
+user1 = {
+    "user": {
+        "username": "Moracha",
+        "email": "jratcher@gmail.com",
+        "password": "password",
+        'callback_url': 'http://www.youtube.com'
+    }
+}
+article = {
+    "article": {
+        "title": "How to train your dragon",
+        "description": "Ever wonder how?",
+        "body": "You have to believe",
+        "tagList": ["reactjs", "angularjs", "dragons"]
+    }
+}
+
+like_data = {
+	"is_like": True
+}

--- a/authors/apps/articles/tests/test_like_dislike_article.py
+++ b/authors/apps/articles/tests/test_like_dislike_article.py
@@ -1,0 +1,107 @@
+import os
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APITestCase, APIClient
+from .article_tests_base_class import ArticlesBaseTest
+from .test_data import *
+from authors.apps.articles.views import *
+
+
+class LikeDislikeArticleTestCase(ArticlesBaseTest):
+    """Test like and dislike of articles"""
+
+    def test_like_article(self):
+        """Test like"""
+        response = self.client.post(self.like_article_url,
+                                    like_data, **self.header_user1, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+        # Test invalid slug
+        response = self.client.post('/api/articles/invalid-slug/like/',
+                                    like_data, **self.header_user1, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        # Test already liked article
+        response = self.client.post(self.like_article_url,
+                                    like_data, **self.header_user1, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_get_like(self):
+        """Test like"""
+        response = self.client.get(self.like_article_url,
+                                   **self.header_user1)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.client.post(self.like_article_url,
+                         like_data, **self.header_user1, format='json')
+        response1 = self.client.get(
+            self.like_article_url, **self.header_user1)
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        # Test invalid slug
+        response = self.client.get('/api/articles/invalid-slug/like/',
+                                   **self.header_user1)
+        detail = "This article has not been found."
+        self.assertEqual(response.data.get('detail'), detail)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_update_like(self):
+        """Test update like to dislike or vice versa"""
+        # test updating like that does not exist
+        response1 = self.client.patch(self.like_article_url + str(3) + '/',
+                                      like_data, **self.header_user1, format='json')
+        self.assertEqual(response1.status_code, status.HTTP_404_NOT_FOUND)
+        # Create like
+        response = self.client.post(self.like_article_url,
+                                    like_data, **self.header_user1, format='json')
+        like_id = response.data.get('id')
+        response1 = self.client.patch(self.like_article_url + str(like_id) + '/',
+                                      like_data, **self.header_user1, format='json')
+        self.assertContains(response1, 'is_like', status_code=200)
+        # Trying to update while not an owner
+        response = self.client.patch(self.like_article_url + str(like_id) + '/',
+                                     like_data, **self.header_user2, format='json')
+        detail = "This user does not own this like"
+        self.assertEqual(response.data.get('detail'), detail)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_delete_like(self):
+        """Test update like to dislike or vice versa"""
+        # test updating like that does not exist
+        response1 = self.client.delete(self.like_article_url + str(3) + '/',
+                                       like_data, **self.header_user1, format='json')
+        self.assertEqual(response1.status_code, status.HTTP_404_NOT_FOUND)
+
+        response = self.client.post(self.like_article_url,
+                                    like_data, **self.header_user1, format='json')
+        like_id = response.data.get('id')
+
+        # Trying to update while not an owner
+        response = self.client.delete(self.like_article_url + str(like_id) + '/',
+                                      like_data, **self.header_user2, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        response1 = self.client.delete(self.like_article_url + str(like_id) + '/',
+                                       like_data, **self.header_user1, format='json')
+        self.assertEqual(response1.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_method_not_allowed(self):
+        """Test module not found class"""
+        response = self.client.put(self.like_article_url,
+                                       like_data, **self.header_user1, format='json')
+        self.assertEqual(response.status_code,
+                         status.HTTP_405_METHOD_NOT_ALLOWED)
+
+    def test_get_likes(self):
+        """Test get likes count endpoint"""
+        self.client.post(self.like_article_url,
+                         like_data, **self.header_user1, format='json')
+
+        response = self.client.get('/api/articles/' + self.slug + '/likes/',
+                                   **self.header_user1)
+        self.assertEqual(response.data.get('likes'), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # Test invalid slug
+        response = self.client.get('/api/articles/invalid-slug/likes/',
+                                   **self.header_user1)
+        detail = "This article has not been found."
+        self.assertEqual(response.data.get('detail'), detail)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,7 +1,9 @@
 from django.urls import path
 from .views import (
     CreateArticleView, GetArticlesView,
-    GetAnArticleView, UpdateAnArticleView
+    GetAnArticleView, UpdateAnArticleView,
+    CreateRetrieveLikeView, UpdateDeleteLikeView,
+    GetArticleLikesView
 )
 app_name = 'articles'
 
@@ -18,5 +20,14 @@ urlpatterns = [
     path(
         'articles/<slug:slug>/edit', UpdateAnArticleView.as_view(),
         name="update_an_article"
-    )
+    ),
+
+    path('articles/<slug:slug>/like/',
+         CreateRetrieveLikeView.as_view(), name="create_like"),
+
+    path('articles/<slug:slug>/like/<int:pk>/',
+         UpdateDeleteLikeView.as_view(), name="update_like"),
+
+    path('articles/<slug:slug>/likes/',
+         GetArticleLikesView.as_view(), name="get_likes")
 ]

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -1,6 +1,7 @@
 from rest_framework import (
     generics, mixins, status
 )
+from rest_framework.views import APIView
 
 from rest_framework.permissions import (
     AllowAny, IsAuthenticated,
@@ -8,8 +9,9 @@ from rest_framework.permissions import (
 from rest_framework.response import Response
 from rest_framework.pagination import LimitOffsetPagination
 from .renderers import ArticleJSONRenderer
-from .serializers import TheArticleSerializer
-from .models import Article
+from .serializers import TheArticleSerializer, LikesSerializer
+from .models import Article, Like
+from authors.apps.core.views import BaseManageView
 
 
 # Create your views here.
@@ -170,3 +172,141 @@ class UpdateAnArticleView(
             no_edit,
             status=status.HTTP_400_BAD_REQUEST
         )
+
+
+class CreateLikeView(generics.CreateAPIView):
+    """This class creates a new like or dislike"""
+    permission_classes = (IsAuthenticated,)
+    serializer_class = LikesSerializer
+
+    def create(self, request, slug):
+        """Creates a like"""
+        data = request.data
+        article = Article.objects.filter(
+            slug=slug, published=True, activated=True).first()
+        if article is None:
+            not_found = {
+                "detail": "This article has not been found."
+            }
+            return Response(data=not_found, status=status.HTTP_404_NOT_FOUND)
+
+        like = Like.objects.filter(
+            user_id=request.user.pk, article_id=article.id).first()
+        if like is not None:
+            like_found = {
+                "detail": "Article already liked or disliked, \
+                    use another route to update."
+            }
+            return Response(data=like_found, status=status.HTTP_400_BAD_REQUEST)
+
+        data['article_id'] = article.id
+        data['user_id'] = request.user.pk
+        serializer = self.get_serializer(data=data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class GetLikeView(generics.RetrieveAPIView):
+    """Fetch like or dislike for an article"""
+    permission_classes = (IsAuthenticated, )
+    queryset = Like.objects.all()
+
+    def get(self, request, slug):
+        article = Article.objects.filter(
+            slug=slug, published=True, activated=True).first()
+        if article is None:
+            not_found = {
+                "detail": "This article has not been found."
+            }
+            return Response(data=not_found, status=status.HTTP_404_NOT_FOUND)
+        like = Like.objects.filter(
+            user_id=request.user.pk, article_id=article.id).first()
+        if like is None:
+            no_like = {
+                "detail": "This user has neither liked \
+                    nor disliked the article."
+            }
+            return Response(data=no_like, status=status.HTTP_404_NOT_FOUND)
+        like_data = {"id": like.id,
+                     "article_id": like.article_id.id,
+                     "user_id": like.user_id.id
+                     }
+        return Response(data=like_data, status=status.HTTP_200_OK)
+
+
+class UpdateLikeView(generics.UpdateAPIView):
+    """Perfom update on likes"""
+    permission_classes = (IsAuthenticated, )
+    serializer_class = LikesSerializer
+    queryset = Like.objects.all()
+
+    def patch(self, request, *args, **kwargs):
+        like_id = kwargs['pk']
+        like = Like.objects.filter(id=like_id).first()
+        if like:
+            like_owner_id = like.user_id.id
+            if like_owner_id != request.user.id:
+                message = {
+                    "detail": "This user does not own this like"
+                }
+                return Response(data=message, status=status.HTTP_403_FORBIDDEN)
+        return self.partial_update(request, *args, **kwargs)
+
+
+class DeleteLikeView(generics.DestroyAPIView):
+    """Delete like"""
+    permission_classes = (IsAuthenticated, )
+    serializer_class = LikesSerializer
+    queryset = Like.objects.all()
+
+    def delete(self, request, *args, **kwargs):
+        like_id = kwargs['pk']
+        like = Like.objects.filter(id=like_id).first()
+        if like:
+            like_owner_id = like.user_id.id
+            if like_owner_id != request.user.id:
+                message = {"detail": "This user does not own this like"}
+                return Response(data=message, status=status.HTTP_403_FORBIDDEN)
+        return self.destroy(request, *args, **kwargs)
+
+
+class CreateRetrieveLikeView(BaseManageView):
+    """Handles create and retrieve likes"""
+    VIEWS_BY_METHOD = {
+        'POST': CreateLikeView.as_view,
+        'GET': GetLikeView.as_view,
+    }
+
+
+class UpdateDeleteLikeView(BaseManageView):
+    """Handles update and retrieve a like"""
+    VIEWS_BY_METHOD = {
+        'PATCH': UpdateLikeView.as_view,
+        'DELETE': DeleteLikeView.as_view,
+    }
+
+
+class GetArticleLikesView(APIView):
+    """Gets all articles' likes and dislikes"""
+    permission_classes = (AllowAny, )
+
+    def get(self, request, slug):
+        article = Article.objects.filter(
+            slug=slug, published=True, activated=True).first()
+        if article is None:
+            not_found = {
+                "detail": "This article has not been found."
+            }
+            return Response(data=not_found, status=status.HTTP_404_NOT_FOUND)
+        likes_queryset = Like.objects.filter(
+            is_like=True, article_id=article.id)
+        dislikes_queryset = Like.objects.filter(
+            is_like=False, article_id=article.id)
+        dislikes_count = dislikes_queryset.count()
+        likes_count = likes_queryset.count()
+        likes_dislikes = {
+            "likes": likes_count,
+            "dislikes": dislikes_count,
+        }
+        return Response(data=likes_dislikes, status=status.HTTP_200_OK)

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -217,7 +217,7 @@ class UserSerializer(serializers.ModelSerializer):
 
 class SocialAuthenticationSerializer(serializers.Serializer):
     """ Holder for  provider, acces token , and access_token_secret"""
-    access_token = serializers.CharField(max_length=500, required=True)
+    access_token = serializers.CharField(max_length=10000, required=True)
     access_token_secret = serializers.CharField(
         max_length=500, allow_blank=True)
     provider = serializers.CharField(max_length=500, required=True)

--- a/authors/apps/authentication/tests/test_social_auth.py
+++ b/authors/apps/authentication/tests/test_social_auth.py
@@ -67,3 +67,4 @@ class Test_Social_Authentication(APITestCase):
 
         response = self.client.post(self.url, self.data, format='json')
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+

--- a/authors/apps/core/views.py
+++ b/authors/apps/core/views.py
@@ -1,0 +1,28 @@
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+
+
+class BaseManageView(APIView):
+    """
+    The base class for ManageViews
+        A ManageView is a view which i
+        s used to dispatch the requests to the appropriate views
+        This is done so that we can use one URL with different
+         methods (GET, PUT, etc)
+    """
+
+    def dispatch(self, request, *args, **kwargs):
+        if request.method not in self.VIEWS_BY_METHOD.keys():
+            return MethodNotAllowedView.as_view()(request, *args, **kwargs)
+        return self.VIEWS_BY_METHOD[request.
+                                    method]()(request, *args, **kwargs)
+
+
+class MethodNotAllowedView(APIView):
+    """Handles Unused methods"""
+
+    def action(self, request, *args, **kwargs):
+        return Response(
+            status=status.HTTP_405_METHOD_NOT_ALLOWED
+        )


### PR DESCRIPTION
**Description**

This Pull request adds the ability for the user to like or dislike an article
<hr>
#### Type of change

- [x] new feature(non-breaking change which adds functionality).

<hr>

**How has this been tested**


- [x] End to End
- [x] Integration
<hr>

**How to test this manually**
- Clone the repository `https://github.com/andela/ah-legion-backend.git`
- run `git checkout --track origin/ft-likes-and-dislikes-164046256`

After logging in and creating an article;
Test the following endpoints using postman:
- POST `/api/articles/<slug>/like/` with payload `{"is_like": true}` to test like/dislike
- GET `/api/articles/<slug>/like/` to test get like
- PATCH `/api/articles/<slug>/like/<pk>/` with payload `{"is_like": false}` to update like/dislike
- DELETE `/api/articles/<slug>/like/<pk>/`to remove like

**Checklist:**
- [x] This follows all the guidelines for this project.

#### Related Stories

[#164046255](https://www.pivotaltracker.com/n/projects/2313280/stories/#164046255)