### PR TITLE
#164046216 Users can comment on articles and other comments

### DIFF
--- a/authors/apps/articles/factories.py
+++ b/authors/apps/articles/factories.py
@@ -1,0 +1,15 @@
+import factory
+
+from authors.apps.core.factories import UserFactory
+
+from .models import Article
+
+
+class ArticleFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = Article
+
+    title = "Article title"
+    draft = "a draft body"
+    author = factory.SubFactory(UserFactory)

--- a/authors/apps/articles/managers.py
+++ b/authors/apps/articles/managers.py
@@ -1,0 +1,25 @@
+from django.db.models import QuerySet
+
+
+class CommentQuerySet(QuerySet):
+    """Custom querysets for for the Comment model."""
+
+    def _active(self):
+        """Return only active comments."""
+        return self.filter(is_active=True)
+
+    def all_comments(self):
+        """Return all active comments."""
+        return self._active()
+
+    def for_author(self, author_profile):
+        """Return active comments for a given author."""
+        return self._active().filter(author=author_profile)
+
+    def for_article(self, article):
+        """Return active comments for a given article."""
+        return self._active().filter(article=article)
+
+    def for_comment(self, comment):
+        """Return active comments for a given article."""
+        return self._active().filter(comment=comment)

--- a/authors/apps/articles/permissions.py
+++ b/authors/apps/articles/permissions.py
@@ -1,0 +1,34 @@
+from rest_framework import permissions
+
+from .models import ThreadedComment
+
+
+class CanCreateComment(permissions.BasePermission):
+    """For read only operations allow, for write perissions make sure they
+    are authenticated.
+    """
+    message = "User cannot create comment unless they are authenticated."
+
+    def has_permission(self, request, view):
+        user = request.user
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        else:
+            return user.is_authenticated
+
+
+class CanEditComment(permissions.BasePermission):
+    """For Read only operations allow, for write operations check
+    whether the user is authenticated and owns the comment.
+    """
+
+    message = "User is not authorized to edit this comment."
+
+    def has_object_permission(self, request, view, obj):
+        user = request.user
+        if request.method in permissions.SAFE_METHODS:
+            return True
+        elif isinstance(obj, ThreadedComment) and user.is_authenticated:
+            return obj.author == user.profile
+
+        return False

--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -1,7 +1,10 @@
 import json
+
 from cloudinary import CloudinaryImage
+
 from rest_framework.renderers import JSONRenderer
 from rest_framework.utils.serializer_helpers import ReturnDict
+
 from ..authentication.models import User
 
 
@@ -59,3 +62,13 @@ class ArticleJSONRenderer(JSONRenderer):
                     'Article': data
                 })
 
+
+class CommentJSONRenderer(JSONRenderer):
+    charset = 'utf-8'
+
+    def render(self, data, media_type=None, renderer_context=None):
+
+        if type(data) == ReturnDict:
+            return json.dumps({'Comment': data})
+
+        return json.dumps({'Comments': data})

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,5 +1,8 @@
 from rest_framework import serializers
-from .models import Article, Like
+
+from authors.apps.profiles.serializers import ProfileSerializer
+
+from .models import Article, Like, ThreadedComment
 
 
 class TheArticleSerializer(serializers.ModelSerializer):
@@ -52,3 +55,39 @@ class LikesSerializer(serializers.ModelSerializer):
         model = Like
         fields = ('id', 'user_id', 'article_id', 'is_like')
         read_only_fields = ['id']
+
+
+class ArticleCommentInputSerializer(serializers.ModelSerializer):
+    """Seriliazes input data and creates a new article comment."""
+    class Meta:
+        model = ThreadedComment
+        fields = ('article', 'author', 'body')
+        extra_kwargs = {'article': {'required': True}}
+
+
+class CommentCommentInputSerializer(serializers.ModelSerializer):
+    """Serializes input data and creates a new comment comment."""
+    class Meta:
+        model = ThreadedComment
+        fields = ('article', 'comment', 'author', 'body')
+        extra_kwargs = {'comment': {'required': True}}
+
+
+class EmbededCommentOutputSerializer(serializers.ModelSerializer):
+    """Seriliazes comment and gives output data."""
+    author = ProfileSerializer()
+
+    class Meta:
+        model = ThreadedComment
+        fields = ('id', 'created_at', 'updated_at', 'body', 'author')
+
+
+class ThreadedCommentOutputSerializer(serializers.ModelSerializer):
+    """Seriliazes comment and gives output data."""
+    author = ProfileSerializer()
+    comments = EmbededCommentOutputSerializer(many=True)
+
+    class Meta:
+        model = ThreadedComment
+        fields = ('id', 'created_at', 'updated_at', 'body', 'author',
+                  'comments')

--- a/authors/apps/articles/tests/test_comment_views.py
+++ b/authors/apps/articles/tests/test_comment_views.py
@@ -1,0 +1,215 @@
+import json
+
+from django.test import TestCase
+from django.urls import reverse
+from django.contrib.auth import get_user_model
+
+from rest_framework import status
+from rest_framework.test import APIClient, force_authenticate
+from rest_framework.test import APIRequestFactory
+
+from authors.apps.core.factories import UserFactory
+
+from ..factories import ArticleFactory
+from ..models import Article, ThreadedComment
+from ..views import CommentListCreateView, CommentRetrieveEditDeleteView
+
+
+class CommentListCreateViewTest(TestCase):
+
+    def setUp(self):
+        self.user1 = UserFactory.create()
+        self.article = ArticleFactory.create(author=self.user1)
+        self.factory = APIRequestFactory()
+
+    def test_author_can_create_article_comments(self):
+        """Test an author can coment on an article."""
+        view = CommentListCreateView.as_view()
+        profile_id = self.user1.id
+        new_comment = {
+            "body": "This is my comment"
+        }
+        request = self.factory.post(
+            reverse("articles:list_create_comments", args=[self.article.slug]),
+            new_comment, format='json')
+        force_authenticate(request, user=self.user1)
+        response = view(request, article_slug=self.article.slug)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_catching_malformed_comment_creation_data(self):
+        view = CommentListCreateView.as_view()
+        request = self.factory.post(
+            reverse("articles:list_create_comments", args=[self.article.slug]),
+            format='json')
+        force_authenticate(request, user=self.user1)
+        response = view(request, article_slug=self.article.slug)
+        expected_data = {
+            "body": ["This field is required."]
+        }
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_author_can_coment_on_comments(self):
+        """Test an author can coment on a comment."""
+        comment = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article)
+        view = CommentListCreateView.as_view()
+        new_comment = {
+            "body": "This is a comment's comment"
+        }
+        url = reverse("articles:comment", args=[self.article.slug, comment.pk])
+        request = self.factory.post(url, new_comment, format='json')
+        force_authenticate(request, user=self.user1)
+        response = view(request, article_slug=self.article.slug, pk=comment.pk)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['body'],
+                         "This is a comment's comment")
+
+    def test_author_only_coment_on_article_comments(self):
+        """Test an author cannot coment on a comment of a comment."""
+        comment = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article)
+        comment_of_comment = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article, comment=comment)
+        view = CommentRetrieveEditDeleteView.as_view()
+        new_comment = {
+            "body": "This is a comment on a comment of a comment"
+        }
+        url = reverse("articles:comment",
+                      args=[self.article.slug, comment_of_comment.pk])
+        request = self.factory.post(url, new_comment, format='json')
+        force_authenticate(request, user=self.user1)
+        response = view(request, article_slug=self.article.slug,
+                        pk=comment_of_comment.pk)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_user_can_comment_on_comment(self):
+        user = get_user_model().objects.create_user(email="bob@email.com",
+                                                    password="pass",
+                                                    username="bob")
+        user.is_verified = True
+        user.save()
+        article = ArticleFactory.create(author=user)
+        comment = ThreadedComment.objects.create(author=user.profile,
+                                               article=article)
+        client = APIClient()
+        data = {"body": "the comment"}
+        login_data = {
+            "user": {
+                "email": user.email,
+                "password": "pass"
+            }
+        }
+        response1 = client.post(reverse("authentication:login"), login_data,
+                                format='json')
+        token = response1.data['token']
+        headers = {
+            'HTTP_AUTHORIZATION': f'Bearer {token}'
+        }
+        url = reverse("articles:comment", args=[article.slug, comment.pk])
+        response = client.post(url, data, format='json', **headers)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['body'], 'the comment')
+
+    def test_coment_on_comments_bad_request(self):
+        """Test an author comenting on a comment with bad data."""
+        comment = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article)
+        view = CommentListCreateView.as_view()
+        request = self.factory.post(
+            reverse("articles:comment", args=[self.article.slug, comment.pk]),
+            format='json')
+        force_authenticate(request, user=self.user1)
+        response = view(request, article_slug=self.article.slug, pk=comment.pk)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_viewing_comments_on_a_non_existent_article(self):
+        view = CommentListCreateView.as_view()
+        request = self.factory.get(reverse("articles:list_create_comments",
+                                           kwargs={'article_slug': 'i-dont-exist'}))
+        response = view(request, article_slug='i-dont-exit')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_viewing_a_list_of_comments(self):
+        view = CommentListCreateView.as_view()
+        article_slug = self.article.slug
+        request = self.factory.get(
+            reverse("articles:list_create_comments", args=[article_slug]),
+            format='json')
+        response = view(request, article_slug=article_slug)
+        self.assertEqual(response.data, [])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_retrieving_a_comment(self):
+        comment = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article)
+        view = CommentRetrieveEditDeleteView.as_view()
+        request = self.factory.get(
+            reverse("articles:comment", args=[self.article.slug, comment.pk]),
+            format='json')
+        response = view(request,
+                        article_slug=self.article.slug, pk=comment.pk)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_updating_a_comment_with_put(self):
+        comment = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article)
+        view = CommentRetrieveEditDeleteView.as_view()
+        comment_update = {"body": "Ive been udated!!"}
+        request = self.factory.put(
+            reverse("articles:comment", args=[self.article.slug, comment.pk]),
+            comment_update, format='json')
+        force_authenticate(request, user=self.user1)
+        response = view(request,
+                        article_slug=self.article.slug, pk=comment.pk)
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+
+    def test_updating_a_comment_of_a_commentwith_put(self):
+        comment = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article)
+        comment2 = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article, comment=comment)
+        view = CommentRetrieveEditDeleteView.as_view()
+        comment_update = {"body": "Ive been udated!!"}
+        request = self.factory.put(
+            reverse("articles:comment", args=[self.article.slug, comment2.pk]),
+            comment_update, format='json')
+        force_authenticate(request, user=self.user1)
+        response = view(request,
+                        article_slug=self.article.slug, pk=comment2.pk)
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+
+    def test_updating_a_comment_with_patch(self):
+        comment = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article)
+        view = CommentRetrieveEditDeleteView.as_view()
+        comment_update = {"body": "Ive been udated!!"}
+        request = self.factory.patch(
+            reverse("articles:comment", args=[self.article.slug, comment.pk]),
+            comment_update, format='json')
+        force_authenticate(request, user=self.user1)
+        response = view(request,
+                        article_slug=self.article.slug, pk=comment.pk)
+        self.assertEqual(response.status_code, status.HTTP_202_ACCEPTED)
+        request2 = self.factory.patch(
+            reverse("articles:comment", args=[self.article.slug, comment.pk]),
+            comment_update, format='json')
+        response2 = view(request2,
+                        article_slug=self.article.slug, pk=comment.pk)
+        self.assertEqual(response2.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_deleting_a_comment(self):
+        comment = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article)
+        view = CommentRetrieveEditDeleteView.as_view()
+        request = self.factory.delete(
+            reverse("articles:comment", args=[self.article.slug, comment.pk]),
+            format='json')
+        force_authenticate(request, user=self.user1)
+        response = view(request, article_slug=self.article.slug, pk=comment.pk)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        request2 = self.factory.get(
+            reverse("articles:comment", args=[self.article.slug, comment.pk]),
+            format='json')
+        force_authenticate(request2, user=self.user1)
+        response2 = view(request2, article_slug=self.article.slug, pk=comment.pk)
+        self.assertEqual(response2.status_code, status.HTTP_404_NOT_FOUND)

--- a/authors/apps/articles/tests/test_managers.py
+++ b/authors/apps/articles/tests/test_managers.py
@@ -1,0 +1,86 @@
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+
+from authors.apps.core.factories import UserFactory
+
+from ..factories import ArticleFactory
+from ..models import ThreadedComment
+
+
+class  CommentActiveObjectsManagerTests(TestCase):
+
+    def setUp(self):
+        self.user1 = UserFactory.create()
+        self.user2 = UserFactory.create()
+        self.article1 = ArticleFactory.create(author=self.user1)
+        self.article2 = ArticleFactory.create(author=self.user2)
+
+    def test_fetching_only_active_comments(self):
+        comment1 = ThreadedComment.objects.create(author=self.user1.profile,
+                                         article=self.article1)
+        comment2 = ThreadedComment.objects.create(author=self.user1.profile,
+                                         article=self.article1)
+        comments = [comment1, comment2]
+        self.assertQuerysetEqual(
+            ThreadedComment.active_objects.all_comments(),
+            [repr(comment) for comment in comments]
+        )
+        comment2.is_active = False
+        comment2.save()
+        comments = [comment1]
+        self.assertQuerysetEqual(
+            ThreadedComment.active_objects.all_comments(),
+            [repr(comment) for comment in comments]
+        )
+
+    def test_fetching_comments_by_author(self):
+        comment1 = ThreadedComment.objects.create(author=self.user1.profile,
+                                         article=self.article1)
+        comment2 = ThreadedComment.objects.create(author=self.user2.profile,
+                                         article=self.article1)
+        comments = [comment1]
+        self.assertQuerysetEqual(
+            ThreadedComment.active_objects.for_author(self.user1.profile),
+            [repr(comment) for comment in comments]
+        )
+        comments = [comment2]
+        self.assertQuerysetEqual(
+            ThreadedComment.active_objects.for_author(self.user2.profile),
+            [repr(comment) for comment in comments]
+        )
+
+    def test_fetching_comments_by_article(self):
+        comment1 = ThreadedComment.objects.create(author=self.user1.profile,
+                                         article=self.article1)
+        comment2 = ThreadedComment.objects.create(author=self.user1.profile,
+                                         article=self.article2)
+        comments = [comment1]
+        self.assertQuerysetEqual(
+            ThreadedComment.active_objects.for_article(article=self.article1),
+            [repr(comment) for comment in comments]
+        )
+        comments = [comment2]
+        self.assertQuerysetEqual(
+            ThreadedComment.active_objects.for_article(article=self.article2),
+            [repr(comment) for comment in comments]
+        )
+
+    def test_fetching_comments_by_comment(self):
+        comment1 = ThreadedComment.objects.create(author=self.user1.profile,
+                                         article=self.article1)
+        comment2 = ThreadedComment.objects.create(author=self.user1.profile,
+                                         article=self.article2, comment=comment1)
+        comment3 = ThreadedComment.objects.create(author=self.user1.profile,
+                                         article=self.article2, comment=comment1)
+        comments = [comment2, comment3]
+        self.assertQuerysetEqual(
+            ThreadedComment.active_objects.for_comment(comment=comment1),
+            [repr(comment) for comment in comments]
+        )
+        comment4 = ThreadedComment.objects.create(author=self.user1.profile,
+                                         article=self.article2, comment=comment1)
+        comments = [comment2, comment3, comment4]
+        self.assertQuerysetEqual(
+            ThreadedComment.active_objects.for_comment(comment=comment1),
+            [repr(comment) for comment in comments]
+        )

--- a/authors/apps/articles/tests/test_models.py
+++ b/authors/apps/articles/tests/test_models.py
@@ -1,0 +1,36 @@
+from django.test import TestCase
+
+from authors.apps.core.factories import UserFactory
+
+from ..factories import ArticleFactory
+from ..models import ThreadedComment
+
+
+class CommentMethodTests(TestCase):
+
+    def setUp(self):
+        self.user1 = UserFactory.create()
+        self.article1 = ArticleFactory.create(author=self.user1)
+
+    def test_comment_string_representation(self):
+        body = "comments and stuff "
+        comment = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article1, body=body)
+        self.assertEqual(str(comment),
+                         f"{str(self.user1.profile)}: comments and stuff ...")
+
+    def test_comment_soft_deletion(self):
+        comment = ThreadedComment.objects.create(author=self.user1.profile,
+                                        article=self.article1)
+        self.assertEqual(comment.is_active, True)
+        comment.soft_delete()
+        self.assertEqual(comment.is_active, False)
+
+    def test_comment_undoing_soft_deletion(self):
+        comment = ThreadedComment.objects.create(author=self.user1.profile,
+                                        article=self.article1)
+        self.assertEqual(comment.is_active, True)
+        comment.soft_delete()
+        self.assertEqual(comment.is_active, False)
+        comment.undo_soft_deletion()
+        self.assertEqual(comment.is_active, True)

--- a/authors/apps/articles/tests/test_renderers.py
+++ b/authors/apps/articles/tests/test_renderers.py
@@ -1,0 +1,39 @@
+from django.test import TestCase
+from django.urls import reverse
+
+from rest_framework.test import APIRequestFactory
+
+from authors.apps.core.factories import UserFactory
+
+
+from ..factories import ArticleFactory
+from ..models import ThreadedComment
+from ..renderers import CommentJSONRenderer
+from ..serializers import ThreadedCommentOutputSerializer
+
+
+class CommentRendererTest(TestCase):
+
+    def setUp(self):
+        self.user1 = UserFactory.create()
+        self.article1 = ArticleFactory.create(author=self.user1)
+        self.factory = APIRequestFactory()
+
+    def test_comment_json_renderer(self):
+        """Test the comment renderer renders comments as expected."""
+        comment1 = ThreadedComment.objects.create(author=self.user1.profile,
+                                                article=self.article1)
+        comment2 = ThreadedComment.objects.create(author=self.user1.profile,
+                                                article=self.article1)
+        request = self.factory.get(reverse("articles:list_create_comments",
+                                           args=[self.article1.slug]),
+                                   format='json')
+        serializer = ThreadedCommentOutputSerializer(
+            comment1, context={"current_user": self.user1})
+        rendered_comment = CommentJSONRenderer().render(serializer.data)
+        self.assertIn("Comment", rendered_comment)
+        comments = ThreadedComment.active_objects.all_comments()
+        serializer2 = ThreadedCommentOutputSerializer(
+            comments, many=True, context={"current_user": self.user1})
+        rendered_comments = CommentJSONRenderer().render(serializer2.data)
+        self.assertIn("Comments", rendered_comments)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,33 +1,28 @@
 from django.urls import path
-from .views import (
-    CreateArticleView, GetArticlesView,
-    GetAnArticleView, UpdateAnArticleView,
-    CreateRetrieveLikeView, UpdateDeleteLikeView,
-    GetArticleLikesView
-)
+
+from . import views
+
+
 app_name = 'articles'
 
+
 urlpatterns = [
-    path(
-        'articles/create', CreateArticleView.as_view(),
-        name="create_article"
-    ),
-    path('articles', GetArticlesView.as_view(), name="get_article"),
-    path(
-        'articles/<slug:slug>', GetAnArticleView.as_view(),
-        name="get_an_article"
-    ),
-    path(
-        'articles/<slug:slug>/edit', UpdateAnArticleView.as_view(),
-        name="update_an_article"
-    ),
-
-    path('articles/<slug:slug>/like/',
-         CreateRetrieveLikeView.as_view(), name="create_like"),
-
-    path('articles/<slug:slug>/like/<int:pk>/',
-         UpdateDeleteLikeView.as_view(), name="update_like"),
-
-    path('articles/<slug:slug>/likes/',
-         GetArticleLikesView.as_view(), name="get_likes")
+    path('create', views.CreateArticleView.as_view(),
+         name="create_article"),
+    path('', views.GetArticlesView.as_view(), name="get_article"),
+    path('<slug:slug>', views.GetAnArticleView.as_view(),
+         name="get_an_article"),
+    path('<slug:slug>/edit', views.UpdateAnArticleView.as_view(),
+         name="update_an_article"),
+    path('<slug:slug>/like/', views.CreateRetrieveLikeView.as_view(),
+         name="create_like"),
+    path('<slug:slug>/like/<int:pk>/', views.UpdateDeleteLikeView.as_view(),
+         name="update_like"),
+    path('<slug:slug>/likes/', views.GetArticleLikesView.as_view(),
+         name="get_likes"),
+    path('<slug:article_slug>/comments/', views.CommentListCreateView.as_view(),
+         name="list_create_comments"),
+    path('<slug:article_slug>/comments/<pk>/',
+         views.CommentRetrieveEditDeleteView.as_view(),
+         name="comment"),
 ]

--- a/authors/apps/core/abstract_models.py
+++ b/authors/apps/core/abstract_models.py
@@ -1,0 +1,12 @@
+from django.db import models
+
+
+class TimeStamped(models.Model):
+    """
+    Provides timstamp fields of created and updated.
+    """
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True

--- a/authors/apps/core/factories.py
+++ b/authors/apps/core/factories.py
@@ -1,0 +1,14 @@
+import factory
+
+from django.contrib.auth import get_user_model
+
+
+class UserFactory(factory.DjangoModelFactory):
+
+    class Meta:
+        model = get_user_model()
+
+    username = factory.sequence(lambda x: f"user_{x}")
+    email = factory.sequence(lambda x: f"user{x}@email.com")
+    password = 'pass'
+    is_verified = True

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -7,11 +7,11 @@ from .views import (
 app_name = 'profiles'
 
 urlpatterns = [
-    path('profiles/<username>/',
+    path('<username>/',
          ProfileRetrieveAPIView.as_view(), name='single-profile'),
-    path('profiles/', ProfilesListAPIView.as_view(), name='profiles'),
-    path('profiles/<str:username>/follow/',
+    path('<str:username>/follow/',
          FollowUnfollowAPIView.as_view(), name='follow-unfollow'),
-    path('profiles/<str:username>/following/',
+    path('<str:username>/following/',
          FollowerFollowingAPIView.as_view(), name="following"),
+    path('', ProfilesListAPIView.as_view(), name='profiles'),
 ]

--- a/authors/settings/base.py
+++ b/authors/settings/base.py
@@ -166,7 +166,6 @@ SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {
 }
 FACEBOOK_EXTENDED_PERMISSIONS = ['email']
 
-
 SOCIAL_AUTH_PIPELINE = (
     'social_core.pipeline.social_auth.social_details',
     'social_core.pipeline.social_auth.social_uid',

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -38,12 +38,19 @@ schema_view = get_schema_view(
 )
 
 
+api_patterns = [
+    path('articles/', include('authors.apps.articles.urls',
+                              namespace='articles')),
+    path('profiles/', include('authors.apps.profiles.urls',
+                              namespace='profiles')),
+    path('', include('authors.apps.authentication.urls',
+                     namespace='authentication')),
+]
+
+
 urlpatterns = [
     path('admin/', admin.site.urls),
-    path('api/', include('authors.apps.authentication.urls',
-                         namespace='authentication')),
-    path('api/', include('authors.apps.profiles.urls',
-                         namespace='profiles')),
+    path('api/', include(api_patterns)),
     url(r'^swagger(?P<format>\.json|\.yaml)$',
         schema_view.without_ui(cache_timeout=0),
         name='schema-json'),
@@ -51,6 +58,4 @@ urlpatterns = [
         name='schema-swagger-ui'),
     url(r'^redoc/$', schema_view.with_ui('redoc', cache_timeout=0),
         name='schema-redoc'),
-
-    path('api/', include('authors.apps.articles.urls',)),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -62,3 +62,4 @@ uritemplate==3.0.0
 urllib3==1.24.1
 whitenoise==4.1.2
 wrapt==1.11.1
+factory-boy==2.11.1


### PR DESCRIPTION
**Description**

This Pull request adds the ability for users to comment on articles and other comments. Authors can also edit or delete the comments they create.
These endpoints have been added:


**POST** `/api/articles/<slug>/comments/`       - Create an article comment 
**GET** `/api/articles/<slug>/comments/`          - List article comments

**GET** `/api/articles/<slug>/comments/<pk>/`        -  Get an article comment with nested comments
**PUT** `/api/articles/<slug>/comments/<pk>/`        - Update a comment 
**PATCH** `/api/articles/<slug>/comments/<pk>/`    - Update a comment
**DELETE** `/api/articles/<slug>/comments/<pk>/`        - Delete a comment
**POST** `/api/articles/<slug>/comments/<pk>/`        - Create a comment for a  another comment 

<hr>
**Type of change**

- [x] new feature(non-breaking change which adds functionality).

<hr>

**How has this been tested**

- [x] End to End
- [x] Integration
<hr>

**How to test this manually**
Using Postman (or any other HTTP client), navigate to [https://ah-legion-staging-pr-28.herokuapp.com](https://ah-legion-staging-pr-28.herokuapp.com) And use the endpoints listed above.

<hr>
**Checklist:**


- [x] This follows all the guidelines for this project.

**Related Stories**
<hr>

[#164046253](https://www.pivotaltracker.com/n/projects/2313280/stories/164046253)