### PR TITLE
#164046257 Users can favorite and unfavorite articles

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -120,3 +120,12 @@ class Snapshot(models.Model):
         ordering = ('-timestamp',)
         verbose_name = _("Comment Snapshot")
         verbose_name_plural = _("Comment Snapshots")
+
+
+class Favorite(models.Model):
+    """Implement storage of favorites"""
+    user_id = models.ForeignKey(
+        settings.AUTH_USER_MODEL, on_delete=models.CASCADE,
+        related_name='favorites')
+    article_id = models.ForeignKey(
+        Article, on_delete=models.CASCADE, related_name='favorites')

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from authors.apps.profiles.serializers import ProfileSerializer
 
-from .models import Article, Like, Snapshot, ThreadedComment
+from .models import Article, Favorite, Like, Snapshot, ThreadedComment
 
 
 class TheArticleSerializer(serializers.ModelSerializer):
@@ -101,3 +101,15 @@ class ThreadedCommentOutputSerializer(serializers.ModelSerializer):
         model = ThreadedComment
         fields = ('id', 'created_at', 'updated_at', 'edited', 'body', 'author',
                   'edit_history', 'comments')
+
+
+class FavoriteSerializer(serializers.ModelSerializer):
+    """
+    Serializers for favorites
+    """
+    class Meta():
+        model = Favorite
+        fields = ('id', 'user_id', 'article_id')
+        read_only_fields = ['id']
+
+

--- a/authors/apps/articles/tests/article_tests_base_class.py
+++ b/authors/apps/articles/tests/article_tests_base_class.py
@@ -39,6 +39,8 @@ class ArticlesBaseTest(APITestCase):
         retrieved_article.published = True
         retrieved_article.save()
         self.like_article_url = '/api/articles/{}/like/'.format(self.slug)
+        self.favorite_article_url = '/api/articles/{}/favorite/'.format(self.slug)
+        self.get_favorites_url = reverse('articles:get_favorites')
 
 
 

--- a/authors/apps/articles/tests/test_favorite_articles.py
+++ b/authors/apps/articles/tests/test_favorite_articles.py
@@ -1,0 +1,71 @@
+import os
+from django.urls import reverse
+from rest_framework import status
+from .article_tests_base_class import ArticlesBaseTest
+from .test_data import *
+from authors.apps.articles.views import *
+
+
+class FavoriteArticleTestCase(ArticlesBaseTest):
+    """Test favoriting an article functionality"""
+
+    def test_favorite_article(self):
+        """Test favorite article"""
+        response = self.client.post(
+            self.favorite_article_url, **self.header_user1)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        # Test already liked article
+        response = self.client.post(self.favorite_article_url,
+                                    like_data, **self.header_user1)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # Test invalid slug
+        response = self.client.post('/api/articles/invalid-slug/favorite/',
+                                    like_data, **self.header_user1, format='json')
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_favorite(self):
+        """Test get favorite"""
+        response = self.client.get(self.favorite_article_url,
+                                   **self.header_user1)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.client.post(self.favorite_article_url,
+                         like_data, **self.header_user1, format='json')
+        response1 = self.client.get(
+            self.favorite_article_url, **self.header_user1)
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        # Test invalid slug
+        response = self.client.get('/api/articles/invalid-slug/favorite/',
+                                   **self.header_user1)
+        detail = "This article has not been found."
+        self.assertEqual(response.data.get('detail'), detail)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_favorites(self):
+        """Test get favorites endpoint"""
+        self.client.post(self.favorite_article_url, **self.header_user1)
+
+        response = self.client.get('/api/articles/favorites/',
+                                   **self.header_user1)
+        self.assertEqual(len(response.data.get('favorites')), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_delete_favorite(self):
+        """Test delete favorite"""
+        # test delete favorite that does not exist
+        response1 = self.client.delete(
+            self.favorite_article_url, **self.header_user1)
+        self.assertEqual(response1.status_code, status.HTTP_404_NOT_FOUND)
+
+        self.client.post(self.favorite_article_url,
+                         **self.header_user1)
+
+        response1 = self.client.delete(
+            self.favorite_article_url, **self.header_user1)
+        self.assertEqual(response1.status_code, status.HTTP_204_NO_CONTENT)
+        # Test with non existent slug
+        response = self.client.delete('/api/articles/invalid-slug/favorite/',
+                                   **self.header_user1)
+        detail = "This article has not been found."
+        self.assertEqual(response.data.get('detail'), detail)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,7 +1,5 @@
-from django.urls import path
-
 from . import views
-
+from django.urls import path
 
 app_name = 'articles'
 
@@ -25,4 +23,12 @@ urlpatterns = [
     path('<slug:article_slug>/comments/<pk>/',
          views.CommentRetrieveEditDeleteView.as_view(),
          name="comment"),
+    path('<slug:slug>/likes/',
+         views.GetArticleLikesView.as_view(), name="get_likes"),
+
+    path('<slug:slug>/favorite/',
+         views.FavoriteView.as_view(), name="favorite"),
+
+    path('favorites/',
+         views.GetUserFavoritesView.as_view(), name="get_favorites"),
 ]


### PR DESCRIPTION
**Description**

This Pull request adds the ability for the user to favorite and unfavorite an article
<hr>
#### Type of change

- [x] new feature(non-breaking change which adds functionality).

<hr>

**How has this been tested**


- [x] End to End
- [x] Integration
<hr>

**How to test this manually**
- Clone the repository `https://github.com/andela/ah-legion-backend.git`
- run `git checkout --track origin/ft-favorite-unfavorite-articles-164046257`

After logging in and creating an article;
Test the following endpoints using postman:
- POST `/api/articles/<slug>/favorite/` to favorite an article
- GET `/api/articles/<slug>/favorite/` to test get favorite
- DELETE `/api/articles/<slug>/favorite/`to remove favorite
- GET  `/api/articles/favorites/` to test get favorites

**Checklist:**
- [x] This follows all the guidelines for this project.

#### Related Stories

[#164046255](https://www.pivotaltracker.com/n/projects/2313280/stories/#164046255)