### PR TITLE
#164046260 Users can add tags to articles

### DIFF
--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -6,6 +6,7 @@ from rest_framework.renderers import JSONRenderer
 from rest_framework.utils.serializer_helpers import ReturnDict
 
 from ..authentication.models import User
+from ..articles.models import Tag
 
 
 class ArticleJSONRenderer(JSONRenderer):
@@ -13,6 +14,13 @@ class ArticleJSONRenderer(JSONRenderer):
     charset = 'utf-8'
 
     def _single_article_formatting(self, data):
+        tags = data.pop("tags")
+        tagList = []
+        for item in tags:
+            this_tag = Tag.objects.filter(pk=item).first()
+            tagList.append(this_tag.tag)
+        data["tagList"] = tagList
+
         author = User.objects.all().filter(
             pk=data['author']).first()
         the_data = {

--- a/authors/apps/articles/tests/test_article_views.py
+++ b/authors/apps/articles/tests/test_article_views.py
@@ -42,7 +42,9 @@ class ArticleViewsTestCase(TestCase):
                 "title": "How to train your dragon",
                 "description": "Ever wonder how?",
                 "body": "You have to believe",
-                "draft": "Giving exellence high priority"
+                "draft": "Giving exellence high priority",
+                "tagList": ["dragons", "training"],
+ 
             }
         }
 
@@ -207,8 +209,9 @@ class ArticleViewsTestCase(TestCase):
             "article": {
                 "title": "I am a champion",
                 "description": "In God we trust.",
-                "body": "One step infron of the other",
+                "body": "One step infront of the other",
                 "draft": "Giving exellence high priority",
+                "tagList": ["andela", "The OG"],
                 "activated": True
             }
         }

--- a/authors/apps/articles/tests/test_models_vol1.py
+++ b/authors/apps/articles/tests/test_models_vol1.py
@@ -1,0 +1,64 @@
+from django.test import TestCase
+
+from authors.apps.articles.models import Tag, Article
+from authors.apps.authentication.models import User
+
+class ArticleModelTestCase(TestCase):
+
+    def setUp(self):
+        self.user_one = User.objects.create(
+            email = "jake@jake.jake",
+            password =  "jakejake",
+            username = "Jake"
+        )
+        self.article_one = Article.objects.create(
+            title = "I am the OG",
+            body = "This is an article by the OG",
+            author = self.user_one
+        )
+
+    def test_article_creation(self):
+        
+        self.assertEqual(
+            self.article_one.__str__(),
+            "I am the OG"
+        )
+
+
+class  TagModelTestCase(TestCase):
+
+    def setUp(self):
+        self.user_one = User.objects.create(
+            email = "jake@jake.jake",
+            password =  "jakejake",
+            username = "Jake"
+        )
+        self.article_one = Article.objects.create(
+            title = "I am the OG",
+            body = "This is an article by the OG",
+            author = self.user_one
+        )
+
+    def test_tag_creation(self):
+        my_tag = Tag.objects.create(tag = "Etomovich")
+        my_tag.save()
+        self.assertEqual(
+            my_tag.slug,
+            "etomovich"
+        )
+
+    def test_delete_tags_without_articles(self):
+        my_tag = Tag(tag = "Etomovich")
+        my_tag.save()
+        remove_tag = my_tag._remove_tags_without_articles("Etomovich")
+        self.assertTrue(remove_tag)
+
+    def test_fail_to_delete_tags_with_articles(self):
+        a_tag = Tag.objects.create(tag = "Andela")
+        self.article_one.tags.add(a_tag)
+        remove_tag = a_tag._remove_tags_without_articles("Andela")
+        self.assertFalse(remove_tag)
+        remove_tag = a_tag._remove_tags_without_articles("Etomovich")
+        self.assertFalse(remove_tag)
+
+


### PR DESCRIPTION
**Description**
<hr>
This PR ensures a user can be able to create articles that he/she can add tags to on article creation and on article update. Users should be able to successfully add tags to articles and remove tags from articles. He or she should then be able to get an article and it comes with its associated tags.
A sample input on article creation/update can be:

```
{
  	"article": {
    		"title": "How to train your dragon",
    		"description": "Ever wonder how?",
    		"body": "You have to believe",
    		"tagList": ["reactjs", "angularjs", "dragons"]
  	}
}
```


**Type of change**
<hr>

- [x] Implement a new feature(user should be able to create articles with tags)

<br>

**How has this been tested**
<hr>

- [x] End to End
- [x] Integration

<br>

**Checklist:**
<hr>

- [x] User should be able to create articles with tags
- [x] Add tests to show functionality

<br>

**Related Stories**
[Add Tags to articles](https://www.pivotaltracker.com/n/projects/2313280/stories/164046260)