### PR TITLE
#164046268 Users Can See Comment Edit History 

### DIFF
--- a/authors/apps/articles/apps.py
+++ b/authors/apps/articles/apps.py
@@ -1,0 +1,8 @@
+from django.apps import AppConfig
+
+
+class ArticlesConfig(AppConfig):
+    name = 'authors.apps.articles'
+
+    def ready(self):
+        from . import signals # noqa

--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -2,6 +2,7 @@ import readtime
 
 from django.conf import settings
 from django.db import models
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from authors.apps.core.abstract_models import TimeStamped
@@ -101,3 +102,21 @@ class ThreadedComment(TimeStamped):
         if self.comment:
             return True
         return False
+
+    @cached_property
+    def edited(self):
+        """Return whether the comment has been edited."""
+        return self.snapshots.all().exists()
+
+
+class Snapshot(models.Model):
+    """Model to take snapshots of comments everytime they are edited."""
+    timestamp = models.DateTimeField(auto_now_add=True)
+    comment = models.ForeignKey('ThreadedComment', related_name='snapshots',
+                                on_delete=models.CASCADE)
+    body = models.TextField(_("Body"))
+
+    class Meta:
+        ordering = ('-timestamp',)
+        verbose_name = _("Comment Snapshot")
+        verbose_name_plural = _("Comment Snapshots")

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -2,7 +2,7 @@ from rest_framework import serializers
 
 from authors.apps.profiles.serializers import ProfileSerializer
 
-from .models import Article, Like, ThreadedComment
+from .models import Article, Like, Snapshot, ThreadedComment
 
 
 class TheArticleSerializer(serializers.ModelSerializer):
@@ -73,21 +73,31 @@ class CommentCommentInputSerializer(serializers.ModelSerializer):
         extra_kwargs = {'comment': {'required': True}}
 
 
+class SnapshotSerializer(serializers.ModelSerializer):
+    """Serializer for displaying comment snapshots."""
+    class Meta:
+        model = Snapshot
+        fields = ('id', 'body', 'timestamp')
+
+
 class EmbededCommentOutputSerializer(serializers.ModelSerializer):
     """Seriliazes comment and gives output data."""
     author = ProfileSerializer()
+    edit_history = SnapshotSerializer(many=True, source='snapshots')
 
     class Meta:
         model = ThreadedComment
-        fields = ('id', 'created_at', 'updated_at', 'body', 'author')
+        fields = ('id', 'created_at', 'updated_at', 'edited', 'body', 'author',
+                  'edit_history')
 
 
 class ThreadedCommentOutputSerializer(serializers.ModelSerializer):
     """Seriliazes comment and gives output data."""
     author = ProfileSerializer()
     comments = EmbededCommentOutputSerializer(many=True)
+    edit_history = SnapshotSerializer(many=True, source='snapshots')
 
     class Meta:
         model = ThreadedComment
-        fields = ('id', 'created_at', 'updated_at', 'body', 'author',
-                  'comments')
+        fields = ('id', 'created_at', 'updated_at', 'edited', 'body', 'author',
+                  'edit_history', 'comments')

--- a/authors/apps/articles/signals.py
+++ b/authors/apps/articles/signals.py
@@ -1,0 +1,15 @@
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+
+from .models import Snapshot, ThreadedComment
+
+
+@receiver(post_save, sender=ThreadedComment)
+def take_comment_snapshot_handler(sender, instance, created, **kwargs):
+    """Make a snapshot of a comment body everytime the comment is edited
+    except for when it has just been newly created.
+    """
+    if created:
+        return
+    snapshot = Snapshot.objects.create(comment=instance, body=instance.body)
+    snapshot.save()

--- a/authors/apps/articles/tests/test_models.py
+++ b/authors/apps/articles/tests/test_models.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from authors.apps.core.factories import UserFactory
 
 from ..factories import ArticleFactory
-from ..models import ThreadedComment
+from ..models import Snapshot, ThreadedComment
 
 
 class CommentMethodTests(TestCase):
@@ -34,3 +34,25 @@ class CommentMethodTests(TestCase):
         self.assertEqual(comment.is_active, False)
         comment.undo_soft_deletion()
         self.assertEqual(comment.is_active, True)
+
+
+class CommentSnapshotSignalTests(TestCase):
+
+    def setUp(self):
+        self.user1 = UserFactory.create()
+        self.article1 = ArticleFactory.create(author=self.user1)
+
+    def test_snapshot_is_saved_only_when_a_comment_is_edited(self):
+        body = "testing comment"
+        comment = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article1, body=body)
+        self.assertNotEqual(comment.snapshots.all(), [])
+        self.assertFalse(comment.edited)
+        comment.body = "edited this comment"
+        comment.save()
+        snapshots = Snapshot.objects.filter(comment=comment)
+        self.assertQuerysetEqual(comment.snapshots.all(),
+                                 [repr(snap) for snap in snapshots])
+        self.assertEqual(snapshots.first().body, comment.body)
+        same_comment = ThreadedComment.objects.get(id = comment.id)
+        self.assertTrue(same_comment.edited)

--- a/authors/settings/base.py
+++ b/authors/settings/base.py
@@ -45,7 +45,7 @@ INSTALLED_APPS = [
     'authors.apps.authentication',
     'authors.apps.core',
     'authors.apps.profiles',
-    'authors.apps.articles',
+    'authors.apps.articles.apps.ArticlesConfig',
 ]
 MIDDLEWARE_CLASSES = (
     'whitenoise.middleware.WhiteNoiseMiddleware',


### PR DESCRIPTION
**Description**

This Pull Request adds the ability for users to see the edit history of comments.
The endpoint below has been added:

**GET** `/api/articles/<slug>/comments/<pk>/`       - a list of the comment's edit history is embeded

<hr>
**Type of change**

- [x] new feature(non-breaking change which adds functionality).

<hr>

**How has this been tested**

- [x] End to End
- [x] Integration
<hr>

**How to test this manually**
Using Postman (or any other HTTP client), navigate to [https://ah-legion-staging-pr-35.com](https://ah-legion-staging-pr-35.herokuapp.com) And use the endpoints listed above.

<hr>
**Checklist:**


- [x] This follows all the guidelines for this project.

**Related Stories**
<hr>

[#164046268](https://www.pivotaltracker.com/n/projects/2313280/stories/164046268)