### PR TITLE
#164046267 Users can highlight text and comment on it

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -77,6 +77,7 @@ class ThreadedComment(TimeStamped):
                                 on_delete=models.CASCADE)
     body = models.TextField(_("Body"))
     is_active = models.BooleanField(default=True)
+    highlight = models.TextField(_("Article Highlight"), blank=True)
 
     objects = models.Manager()
     active_objects = managers.CommentQuerySet.as_manager()
@@ -108,6 +109,13 @@ class ThreadedComment(TimeStamped):
         """Return whether the comment has been edited."""
         return self.snapshots.all().exists()
 
+    @property
+    def is_article_highlighted(self):
+        """Return whether an article has been highlighted in this comment."""
+        if self.highlight:
+            return True
+        return False
+
 
 class Snapshot(models.Model):
     """Model to take snapshots of comments everytime they are edited."""
@@ -115,6 +123,7 @@ class Snapshot(models.Model):
     comment = models.ForeignKey('ThreadedComment', related_name='snapshots',
                                 on_delete=models.CASCADE)
     body = models.TextField(_("Body"))
+    highlight = models.TextField(_("Highlight"), null=True, blank=True)
 
     class Meta:
         ordering = ('-timestamp',)

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -59,9 +59,11 @@ class LikesSerializer(serializers.ModelSerializer):
 
 class ArticleCommentInputSerializer(serializers.ModelSerializer):
     """Seriliazes input data and creates a new article comment."""
+    highlight = serializers.CharField(min_length=1, required=False)
+
     class Meta:
         model = ThreadedComment
-        fields = ('article', 'author', 'body')
+        fields = ('article', 'author', 'body', "highlight")
         extra_kwargs = {'article': {'required': True}}
 
 
@@ -77,18 +79,21 @@ class SnapshotSerializer(serializers.ModelSerializer):
     """Serializer for displaying comment snapshots."""
     class Meta:
         model = Snapshot
-        fields = ('id', 'body', 'timestamp')
+        fields = ('id', 'highlight', 'body', 'timestamp')
 
 
 class EmbededCommentOutputSerializer(serializers.ModelSerializer):
     """Seriliazes comment and gives output data."""
     author = ProfileSerializer()
     edit_history = SnapshotSerializer(many=True, source='snapshots')
+    is_highlight_comment = serializers.BooleanField(
+        source="is_article_highlighted")
 
     class Meta:
         model = ThreadedComment
-        fields = ('id', 'created_at', 'updated_at', 'edited', 'body', 'author',
-                  'edit_history')
+        fields = ('id', 'created_at', 'updated_at', 'edited',
+                  'is_highlight_comment', 'highlight', 'body',
+                  'author', 'edit_history')
 
 
 class ThreadedCommentOutputSerializer(serializers.ModelSerializer):
@@ -96,8 +101,11 @@ class ThreadedCommentOutputSerializer(serializers.ModelSerializer):
     author = ProfileSerializer()
     comments = EmbededCommentOutputSerializer(many=True)
     edit_history = SnapshotSerializer(many=True, source='snapshots')
+    is_highlight_comment = serializers.BooleanField(
+        source="is_article_highlighted")
 
     class Meta:
         model = ThreadedComment
-        fields = ('id', 'created_at', 'updated_at', 'edited', 'body', 'author',
+        fields = ('id', 'created_at', 'updated_at', 'edited', 'body',
+                  'is_highlight_comment', 'highlight', 'author',
                   'edit_history', 'comments')

--- a/authors/apps/articles/signals.py
+++ b/authors/apps/articles/signals.py
@@ -11,5 +11,6 @@ def take_comment_snapshot_handler(sender, instance, created, **kwargs):
     """
     if created:
         return
-    snapshot = Snapshot.objects.create(comment=instance, body=instance.body)
+    snapshot = Snapshot.objects.create(comment=instance, body=instance.body,
+                                       highlight=instance.highlight)
     snapshot.save()

--- a/authors/apps/articles/tests/test_models.py
+++ b/authors/apps/articles/tests/test_models.py
@@ -56,3 +56,21 @@ class CommentSnapshotSignalTests(TestCase):
         self.assertEqual(snapshots.first().body, comment.body)
         same_comment = ThreadedComment.objects.get(id = comment.id)
         self.assertTrue(same_comment.edited)
+
+
+class ArticleHighlightComment(TestCase):
+
+    def setUp(self):
+        self.user1 = UserFactory.create()
+        self.article = ArticleFactory.create(author=self.user1)
+
+    def test_commenting_on_article_with_text_hightlight(self):
+        body = "I dont think so"
+        comment = ThreadedComment.objects.create(
+            author=self.user1.profile, article=self.article, body=body)
+        body2 = "I dont think so"
+        self.assertFalse(comment.is_article_highlighted)
+        comment2 = ThreadedComment.objects.create(author=self.user1.profile,
+                                                  article=self.article, body=body2,
+                                                  highlight="blah blah text")
+        self.assertTrue(comment2.is_article_highlighted)


### PR DESCRIPTION
**Description**

This feature gives the ability to highlight specific text in an article and comment on it
<hr>
**Type of change**

- [x] new feature(non-breaking change which adds functionality).

<hr>

**How has this been tested**


- [x] Unit tests
<hr>

**How to test this manually**
- Clone the repository `https://github.com/andela/ah-legion-backend.git`
- run `git checkout --track origin/ft-article-hightlight-comment-164046267`

After logging in and creating an article;
Test the following endpoints using postman:

**POST** `/api/articles/<slug>/comments/`       - Create an article comment 
**PATCH** `/api/articles/<slug>/comments/<pk>/`    - Update a comment
**POST** `/api/articles/<slug>/comments/<pk>/`        - Create a comment for a  another comment 

**Checklist:**
- [x] This follows all the guidelines for this project.

#### Related Stories

[#164046267](https://www.pivotaltracker.com/n/projects/2313280/stories/164046267)