### PR TITLE
#164046252 Users can Rate Articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,3 +479,51 @@ No additional parameters required
 ### Get Tags
 
 `GET /api/tags`
+
+## Create an Article Rating
+
+`POST /api/articles/<slug>/rate/`
+
+Example request body:
+
+```source-json
+{
+	"rating":{
+		"value":"3",
+		"review":"Quite interesting."
+	}
+}
+```
+
+Requires authentication
+
+Accepted fields: `value`, `review`
+
+## Update an Article Rating
+
+`PUT api/articles/<slug>/rate/`
+
+Example request body:
+
+```source-json
+{
+	"rating":{
+		"value":"4",
+		"review":"Quite interesting. I loved the ending."
+	}
+}
+```
+
+Requires authentication
+
+Accepted fields: `value`, `review`
+
+## Get an Article's Ratings
+
+`GET api/articles/<slug>/ratings/`
+
+
+Returns all reviews attached to an article
+
+
+

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -2,17 +2,20 @@ from rest_framework import serializers
 
 from authors.apps.profiles.serializers import ProfileSerializer
 
-from .models import Article, Favorite, Like, Snapshot, ThreadedComment
+from .models import (Article, Favorite, Like, Snapshot,
+                     ThreadedComment, Rating)
 
 
 class TheArticleSerializer(serializers.ModelSerializer):
 
     reading_time = serializers.ReadOnlyField(source='get_reading_time')
+    average_rating = serializers.ReadOnlyField(source='get_average_rating')
 
     class Meta:
         model = Article
         fields = [
-            'id', 'title', 'body', 'draft', 'slug', 'reading_time',
+            'id', 'title', 'body', 'draft', 'slug',
+            'reading_time', 'average_rating',
             'editing', 'description', 'published', 'activated',
             "created_at", "updated_at", 'author'
         ]
@@ -113,3 +116,28 @@ class FavoriteSerializer(serializers.ModelSerializer):
         read_only_fields = ['id']
 
 
+class RatingSerializer(serializers.ModelSerializer):
+    """Handles serialization of article ratings."""
+    value = serializers.IntegerField(
+        min_value=1,
+        max_value=5,
+        required=True)
+
+    class Meta:
+        model = Rating
+        fields = ['user', 'article', 'value', 'review']
+
+    def get_article(self, slug):
+        article = Article.objects.get(slug=slug, published=True, activated=True)
+        return article
+
+
+class ArticleRatingSerializer(serializers.ModelSerializer):
+    """Handles deserialization of article ratings."""
+    image = serializers.ReadOnlyField(source='get_image')
+    username = serializers.ReadOnlyField(source='get_username')
+    user = {"username": username, "image": image}
+
+    class Meta:
+        model = Rating
+        fields = ['value', 'review', 'username', 'image']

--- a/authors/apps/articles/tests/article_tests_base_class.py
+++ b/authors/apps/articles/tests/article_tests_base_class.py
@@ -41,8 +41,8 @@ class ArticlesBaseTest(APITestCase):
         self.like_article_url = '/api/articles/{}/like/'.format(self.slug)
         self.favorite_article_url = '/api/articles/{}/favorite/'.format(self.slug)
         self.get_favorites_url = reverse('articles:get_favorites')
-
-
-
-
-
+        self.rate_url = '/api/articles/{}/rate/'.format(self.slug)
+        self.get_rate_url = '/api/articles/{}/ratings/'.format(self.slug)
+        self.non_existent_article = '/api/articles/hi/rate/'
+        self.get_non_existent_article = '/api/articles/hi/ratings/'
+        self.article_rating = '/api/articles/'

--- a/authors/apps/articles/tests/test_article_rating.py
+++ b/authors/apps/articles/tests/test_article_rating.py
@@ -1,0 +1,99 @@
+from rest_framework import status
+
+from .article_tests_base_class import ArticlesBaseTest
+from .test_data import *
+from authors.apps.articles.models import Rating, Article
+
+
+class ArticleRatingTestCase(ArticlesBaseTest):
+    """Test like and dislike of articles"""
+
+    def test_valid_rating(self):
+        """Tests for a valid rating post request."""
+        res = self.client.post(self.rate_url,
+                               valid_rate_data1, **self.header_user2, format='json')
+        self.assertEqual(res.data, valid_data_rasponse)
+        self.assertEqual(res.status_code, status.HTTP_201_CREATED)
+
+    def test_rate_non_existent_article(self):
+        """Tests a post request for a non-existent article."""
+        res = self.client.post(self.non_existent_article,
+                               valid_rate_data1, **self.header_user2, format='json')
+        self.assertEqual(res.data, non_existent_article_response)
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_author_rating(self):
+        """Tests for a post request where the user is also the article author."""
+        res = self.client.post(self.rate_url,
+                               valid_rate_data1, **self.header_user1, format='json')
+        self.assertEqual(res.data, author_rating_data_response)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_rating_twice(self):
+        """Tests for a post request by a user to rate an article they have already rated."""
+        self.client.post(self.rate_url,
+                         valid_rate_data1, **self.header_user2, format='json')
+        res = self.client.post(self.rate_url,
+                               valid_rate_data1, **self.header_user2, format='json')
+        self.assertEqual(res.data, rating_twice_data_response)
+        self.assertEqual(res.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_reviews(self):
+        """Tests for a valid get request to fetch all reviews."""
+        self.client.post(self.rate_url,
+                         valid_rate_data1, **self.header_user2, format='json')
+        res = self.client.get(self.get_rate_url, **self.header_user2, format='json')
+        self.assertEqual(res.status_code, status.HTTP_200_OK)
+
+    def test_no_reviews(self):
+        """Tests for a get request to fetch non-existent reviews."""
+        self.client.post(self.rate_url,
+                         valid_rate_data2, **self.header_user2, format='json')
+        res = self.client.get(self.get_rate_url, **self.header_user2, format='json')
+        self.assertEqual(res.data, no_review_data_response)
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_article_not_rated(self):
+        """Tests for an article that has not been rated when getting articles."""
+        res = self.client.get(self.article_rating, **self.header_user2, format='json')
+        self.assertEqual(res.data['results'][0]['average_rating'], no_ratings_data_response)
+
+    def test_get_non_existent_article(self):
+        """Tests for a request to get the rating of a non-existent article."""
+        res = self.client.get(self.get_non_existent_article, **self.header_user2, format='json')
+        self.assertEqual(res.data, non_existent_article_response)
+        self.assertEqual(res.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_rated_article(self):
+        """Tests for an article that has been rated when getting articles."""
+        self.client.post(self.rate_url,
+                         valid_rate_data1, **self.header_user2, format='json')
+        res = self.client.get(self.article_rating, **self.header_user2, format='json')
+        self.assertEqual(res.data['results'][0]['average_rating'], 2.0)
+
+    def test_update_rating(self):
+        """Tests for a valid request to update a rating."""
+        self.client.post(self.rate_url,
+                         valid_rate_data1, **self.header_user2, format='json')
+        res = self.client.put(self.rate_url, update_rating_data, **self.header_user2, format='json')
+        self.assertEqual(res.data, update_rating_data_response)
+        
+    def test_update_not_rated_article(self):
+        """Tests for a valid request to update a rating."""
+        self.client.post(self.rate_url,
+                         valid_rate_data1, **self.header_user1, format='json')
+        res = self.client.put(self.rate_url, update_rating_data, **self.header_user2, format='json')
+        self.assertEqual(res.data, not_rated_data_response)
+
+    def test_update_non_existent_article(self):
+        """Tests for a valid request to update a rating."""
+        res = self.client.put(self.non_existent_article, update_rating_data, **self.header_user2, format='json')
+        self.assertEqual(res.data, non_existent_article_response)
+
+    def test_model_representation(self):
+        retrieved_article = Article.objects.filter(slug=self.slug).first()
+        retrieved_article.published = True
+        retrieved_article.save()
+        self.rating = Rating.objects.create(article=retrieved_article, user= self.user2,
+                                            value=1, review="no way")
+        self.assertEqual(str(self.rating), "This is rating no: 1")

--- a/authors/apps/articles/tests/test_data.py
+++ b/authors/apps/articles/tests/test_data.py
@@ -27,3 +27,46 @@ article = {
 like_data = {
 	"is_like": True
 }
+
+valid_rate_data1 = {"rating":
+{"value": "2",
+"review": "How do you train your dragon?"}}
+
+valid_rate_data2 = {"rating":
+{"value": "3","review": ""}
+}
+
+update_rating_data = {"rating": {
+"value": "3",
+"review": "That's great!"
+}
+}
+
+valid_data_rasponse = {
+    "message": "Article rated."
+}
+
+author_rating_data_response = {
+    "message": "You cannot rate your own article."
+}
+
+no_ratings_data_response = "This article has not been rated."
+
+non_existent_article_response = {
+    "message": "This article was not found."
+}
+no_review_data_response = {
+    "message": "This article has no reviews."
+}
+
+rating_twice_data_response = {
+    "message": "You have already rated this article."
+}
+
+update_rating_data_response = {
+    "message": "Rating updated."
+}
+
+not_rated_data_response ={
+"message": "You have not rated this article."
+}

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,6 +1,7 @@
 from . import views
 from django.urls import path
 
+
 app_name = 'articles'
 
 
@@ -31,4 +32,10 @@ urlpatterns = [
 
     path('favorites/',
          views.GetUserFavoritesView.as_view(), name="get_favorites"),
+    path('<slug:slug>/likes/',
+         views.GetArticleLikesView.as_view(), name="get_likes"),
+    path('<slug:slug>/rate/',
+         views.RatingView.as_view(), name="rate"),
+    path('<slug:slug>/ratings/',
+         views.GetRatingView.as_view(), name="get_rating")
 ]


### PR DESCRIPTION
### Description
Adds Article Rating functionality. Leaving a rating gives authors a general idea of what one feels about their content.

### Type of change
- [x] Non-breaking change (Users can rate each other's articles).

### How Has This Been Tested
- [x] Integration tests
- [x] End to end testing

### Checklist
- [x] Feature passes team's flake8 standards
- [x] New and existing unit tests pass locally with my changes

### How can this be manually tested?
The feature has three endpoints. `GET` is available to any user wheares `PUT` and `POST` are available only to authenticated users.

`POST /api/articles/<slug>/rate/`

Example request body:

```source-json
{
    "rating":{
        "value":"3",
        "review":"Quite interesting."
    }
}
```


`PUT api/articles/<slug>/rate/`

Example request body:

```source-json
{
    "rating":{
        "value":"4",
        "review":"Quite interesting. I loved the ending."
    }
}
```

`GET api/articles/<slug>/ratings/`

#### PT
[#164046248](https://www.pivotaltracker.com/story/show/164046252)
