### PR TITLE
#164772118 Reorganize Authentication URLs

### DIFF
--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -5,21 +5,20 @@ from .views import (LoginAPIView, RegistrationAPIView,
                     EmailVerificationView, CreateEmailVerificationTokenAPIView,
                     PasswordResetView)
 
+
 app_name = 'authentication'
 
+
 urlpatterns = [
-    path('user/', UserRetrieveUpdateAPIView.as_view(), name='get users'),
-    path('users/', RegistrationAPIView.as_view(), name='register'),
-    path('users/login/', LoginAPIView.as_view(), name='login'),
-    path('users/oauth/', SocialAuthenticationView.as_view(),
+    path('', UserRetrieveUpdateAPIView.as_view(), name='get users'),
+    path('register/', RegistrationAPIView.as_view(), name='register'),
+    path('login/', LoginAPIView.as_view(), name='login'),
+    path('oauth/', SocialAuthenticationView.as_view(),
          name='social_login'),
-    path(
-        'activate/<str:token>',
-        EmailVerificationView.as_view(), name='verify email'),
+    path('activate/<str:token>',
+         EmailVerificationView.as_view(), name='verify email'),
     path('token/', CreateEmailVerificationTokenAPIView.as_view(),
          name='new verification token'),
-    path('users/password-reset/', PasswordResetView.as_view(),
+    path('password-reset/', PasswordResetView.as_view(),
          name='password-reset')
-
-
 ]

--- a/authors/apps/profiles/tests/test_views.py
+++ b/authors/apps/profiles/tests/test_views.py
@@ -79,7 +79,8 @@ class TestProfileViews(TestCase):
         """
 
         response = self.test_client.post(
-            "/api/users/login/", data=json.dumps(self.data), content_type='application/json')
+            reverse("authentication:login"),
+            data=json.dumps(self.data), content_type='application/json')
         token = response.json()['user']['token']
         return token
 
@@ -92,7 +93,8 @@ class TestProfileViews(TestCase):
         Returns: an issued post request to the user registration endpoint
         """
         return self.test_client.post(
-            "/api/users/", data=json.dumps(user_details_dict), content_type='application/json')
+            reverse("authentication:register"),
+            data=json.dumps(user_details_dict), content_type='application/json')
     
     def follow_user(self, username, token):
         """This method sends a follow request to a user"""

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -43,8 +43,8 @@ api_patterns = [
                               namespace='articles')),
     path('profiles/', include('authors.apps.profiles.urls',
                               namespace='profiles')),
-    path('', include('authors.apps.authentication.urls',
-                     namespace='authentication')),
+    path('user/', include('authors.apps.authentication.urls',
+                          namespace='authentication')),
 ]
 
 


### PR DESCRIPTION
#### Description
Prefixes all urls in the authentication all with `/user/`
renames the user registration url to `/api/user/register/`

#### Type of change
- [x] Breaking Change(user registration URL renamed to `/api/user/register/` )
- [x] Non-breaking changes (URL prefix for authentication app urls moved to `authors.urls.py`)

#### How Has This Been Tested?
- [x] Unit Tests

#### Checklist:
- [x] Feature passes team flake8 standards
- [x] Refactored prior tests to make them pass considering I have breaking changes

### How can this be manually tested?
- Follow instructions on the README page and set up your environment locally.
- Use the URL `/api/user/register/` to register users.

#### PT
[#164772118](https://www.pivotaltracker.com/story/show/164772118)