### PR TITLE
#164807964 Display correct rating value on each article

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -10,7 +10,6 @@ from authors.apps.profiles.models import Profile
 
 from . import managers
 from .utils import generate_unique_slug
-from django.db.models import Avg
 from cloudinary import CloudinaryImage
 from django.utils.text import slugify
 
@@ -50,15 +49,6 @@ class Article(models.Model):
         unit = " minutes"
 
         return str(reading_time) + unit
-
-    def get_average_rating(self):
-        if Rating.objects.all().count() > 0:
-            rating = Rating.objects.all().aggregate(Avg('value'))
-            return round(rating['value__avg'], 1)
-        return "This article has not been rated."
-
-    class Meta:
-        ordering = ["-created_at", "-updated_at"]
 
 
 class Like(models.Model):

--- a/authors/apps/articles/tests/test_data.py
+++ b/authors/apps/articles/tests/test_data.py
@@ -43,7 +43,7 @@ update_rating_data = {"rating": {
 }
 
 valid_data_rasponse = {
-    "message": "Article rated."
+    "message": "You have rated this article: how-to-train-your-dragon"
 }
 
 author_rating_data_response = {

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -550,7 +550,7 @@ class RatingView(APIView):
             serializer.is_valid(raise_exception=True)
             serializer.save()
             return Response({"message":
-                             "Article rated."},
+                             "You have rated this article: " + slug},
                             status=status.HTTP_201_CREATED)
 
         except Article.DoesNotExist:


### PR DESCRIPTION
### What does this PR do?
Fixes a bug. When one article is rated, the average value now  appears only on that article and not on all the articles.

#### Type of change

- [x] Non-breaking change (article rating)

#### How Has This Been Tested?
- [x] Unit tests

#### Checklist:
- [x] When one article is rated, the average rating  value appears on that article only.

#### PT
[#164807964](https://www.pivotaltracker.com/story/show/164807964)