### PR TITLE
#164821395 Save First Comment Body As First Edit

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -108,8 +108,10 @@ class ThreadedComment(TimeStamped):
 
     @cached_property
     def edited(self):
-        """Return whether the comment has been edited."""
-        return self.snapshots.all().exists()
+        """Return whether the comment has been edited.
+        The first snapshot saved is of the original comment so its not counted.
+        """
+        return self.snapshots.count() > 1
 
 
 class Snapshot(models.Model):

--- a/authors/apps/articles/signals.py
+++ b/authors/apps/articles/signals.py
@@ -5,11 +5,9 @@ from .models import Snapshot, ThreadedComment
 
 
 @receiver(post_save, sender=ThreadedComment)
-def take_comment_snapshot_handler(sender, instance, created, **kwargs):
+def take_comment_snapshot_handler(sender, instance, **kwargs):
     """Make a snapshot of a comment body everytime the comment is edited
     except for when it has just been newly created.
     """
-    if created:
-        return
     snapshot = Snapshot.objects.create(comment=instance, body=instance.body)
     snapshot.save()


### PR DESCRIPTION
#### Description
Fixes a bug where the original comment body is not saved as a previous edit when the
comment is saved. 

#### Type of change
- [x] Non-breaking changes (save original comment body as the first edit)

#### How Has This Been Tested?
- [x] Unit Tests

#### Checklist:
- [x] Feature passes team flake8 standards

### How can this be manually tested?
- Follow instructions on the README page and set up your environment locally.


#### PT
[#164821395](https://www.pivotaltracker.com/story/show/164821395)