### PR TITLE
#164753579 Fix article module output feedback

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Authentication required, returns the updated Article
 
 Optional fields: `title`, `description`, `body`
 
-The `slug` also gets updated when the `title` is changed
+The `slug` does not get updated when the `title` is changed
 
 ### Delete Article
 
@@ -428,7 +428,7 @@ Authentication required
 
 ### Pubish Article
 
-`PATCH /api/articles/:slug/edit`
+`PATCH /api/articles/:slug/publish`
 
 Authentication required
 

--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -21,7 +21,6 @@ class Article(models.Model):
     slug = models.SlugField(max_length=170, db_index=True, unique=True)
     body = models.TextField(blank=False, null=False)
     draft = models.TextField(blank=True, null=True)
-    # [editing]True if user is currently editing the article
     editing = models.BooleanField(default=False)
     description = models.CharField(max_length=255, null=True)
     published = models.BooleanField(default=False)
@@ -30,7 +29,7 @@ class Article(models.Model):
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     author = models.ForeignKey(
-        settings.AUTH_USER_MODEL,
+        Profile, related_name="articles",
         on_delete=models.CASCADE
     )
 
@@ -43,12 +42,6 @@ class Article(models.Model):
         '''Saves all the changes of model article'''
         if not self.slug:
             self.slug = generate_unique_slug(self, "title", "slug")
-
-        update_slug = generate_unique_slug(self, "title", "slug")
-        art = Article.objects.filter(slug=self.slug).first()
-        if art and art.title != self.title:
-            self.slug = update_slug
-
         super().save(*args, **kwargs)
 
     def get_reading_time(self):

--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -1,11 +1,8 @@
 import json
 
-from cloudinary import CloudinaryImage
-
 from rest_framework.renderers import JSONRenderer
 from rest_framework.utils.serializer_helpers import ReturnDict
 
-from ..authentication.models import User
 from ..articles.models import Tag
 
 
@@ -20,55 +17,24 @@ class ArticleJSONRenderer(JSONRenderer):
             this_tag = Tag.objects.filter(pk=item).first()
             tagList.append(this_tag.tag)
         data["tagList"] = tagList
-
-        author = User.objects.all().filter(
-            pk=data['author']).first()
-        the_data = {
-            "username": author.username,
-            "bio": "None",
-            "image": "None"
-        }
-        profile = author.profile
-        if profile:
-            the_data["bio"] = profile.bio
-            img = str(author.profile.image)
-            image_url = CloudinaryImage(img).build_url(
-                width=100, height=150, crop='fill'
-            )
-            the_data["image"] = image_url
-        data['author'] = the_data
         return data
 
     def render(self, data, media_type=None, renderer_context=None):
         """Return data in json format."""
         if type(data) == ReturnDict:
             # single article
-            try:
-                my_data = self._single_article_formatting(data)
-                return json.dumps({
-                    'Article': my_data
-                })
-            except (KeyError, TypeError, ValueError):
-                return json.dumps({
-                    'Article': data
-                })
+            my_data = self._single_article_formatting(data)
+            return json.dumps({
+                'Article': my_data
+            })
         else:
             # many articles
-            try:
-                reply = []
-                the_articles = data['results']
-                for item in the_articles:
-                    my_data = self._single_article_formatting(item)
-                    reply.append(my_data)
-
-                data['results'] = reply
-                return json.dumps({
-                    'Articles': data
-                })
-            except (KeyError, TypeError, ValueError):
-                return json.dumps({
-                    'Article': data
-                })
+            if "results" in data.keys():
+                for item in data["results"]:
+                    item = self._single_article_formatting(item)
+            return json.dumps({
+                'Articles': data
+            })
 
 
 class CommentJSONRenderer(JSONRenderer):

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 
 from authors.apps.profiles.serializers import ProfileSerializer
-
+from authors.apps.profiles.models import Profile
 from .models import (Article, Favorite, Like, Snapshot,
                      ThreadedComment, Rating, Tag)
 
@@ -10,6 +10,7 @@ class TheArticleSerializer(serializers.ModelSerializer):
 
     reading_time = serializers.ReadOnlyField(source='get_reading_time')
     average_rating = serializers.ReadOnlyField(source='get_average_rating')
+    author = ProfileSerializer(read_only=True)
 
     class Meta:
         model = Article
@@ -27,8 +28,11 @@ class TheArticleSerializer(serializers.ModelSerializer):
         tags_data = None
         if 'tags' in validated_data.keys():
             tags_data = article_data.pop("tags")
-        article = Article.objects.create(**article_data)
 
+        current_user = self.context.get('current_user', None)
+        user_profile = Profile.objects.filter(user=current_user).first()
+        article_data["author"] = user_profile
+        article = Article.objects.create(**article_data)
         if tags_data:
             for item in tags_data:
                 my_tag = Tag()

--- a/authors/apps/articles/tests/test_article_views.py
+++ b/authors/apps/articles/tests/test_article_views.py
@@ -109,7 +109,7 @@ class ArticleViewsTestCase(TestCase):
         self.assertEqual(respo.status_code, status.HTTP_201_CREATED)
 
         # Publish article of user1
-        my_url = '/api/articles/{}/edit'.format(respo.data['slug'])
+        my_url = '/api/articles/{}/publish/'.format(respo.data['slug'])
         respo1 = client.patch(
             my_url,
             **self.header_user1,
@@ -130,7 +130,7 @@ class ArticleViewsTestCase(TestCase):
         self.assertEqual(respo.status_code, status.HTTP_201_CREATED)
 
         # Get an article that is not there
-        my_url = '/api/articles/{}'.format(respo.data['slug'])
+        my_url = '/api/articles/{}/'.format(respo.data['slug'])
         respo1 = client.get(
             my_url,
             **self.header_user1,
@@ -139,7 +139,7 @@ class ArticleViewsTestCase(TestCase):
         self.assertEqual(respo1.status_code, status.HTTP_404_NOT_FOUND)
 
         # Publish article of user1
-        my_url = '/api/articles/{}/edit'.format(respo.data['slug'])
+        my_url = '/api/articles/{}/publish/'.format(respo.data['slug'])
         respo2 = client.patch(
             my_url,
             **self.header_user1,
@@ -148,7 +148,7 @@ class ArticleViewsTestCase(TestCase):
         self.assertEqual(respo2.status_code, status.HTTP_200_OK)
 
         # Get an article that is there
-        my_url = '/api/articles/{}'.format(respo.data['slug'])
+        my_url = '/api/articles/{}/'.format(respo.data['slug'])
         respo3 = client.get(
             my_url,
             **self.header_user1,
@@ -164,7 +164,7 @@ class ArticleViewsTestCase(TestCase):
         self.assertEqual(respo.status_code, status.HTTP_201_CREATED)
 
         # Publish article of user1
-        my_url = '/api/articles/{}/edit'.format(respo.data['slug'])
+        my_url = '/api/articles/{}/publish/'.format(respo.data['slug'])
         respo1 = client.patch(
             my_url,
             **self.header_user1,
@@ -173,6 +173,7 @@ class ArticleViewsTestCase(TestCase):
         self.assertEqual(respo1.status_code, status.HTTP_200_OK)
 
         # Delete article of user1
+        my_url = '/api/articles/{}/edit/'.format(respo.data['slug'])
         respo1 = client.delete(
             my_url,
             **self.header_user1,
@@ -197,7 +198,7 @@ class ArticleViewsTestCase(TestCase):
         self.assertEqual(respo.status_code, status.HTTP_201_CREATED)
 
         # Publish article of user1
-        my_url = '/api/articles/{}/edit'.format(respo.data['slug'])
+        my_url = '/api/articles/{}/publish/'.format(respo.data['slug'])
         respo1 = client.patch(
             my_url,
             **self.header_user1,
@@ -217,6 +218,7 @@ class ArticleViewsTestCase(TestCase):
         }
 
         # Try to update the article with wrong user
+        my_url = '/api/articles/{}/edit/'.format(respo.data['slug'])
         respo1 = client.put(
             my_url,
             update_input,
@@ -228,6 +230,20 @@ class ArticleViewsTestCase(TestCase):
                          'You are not the owner of the article.')
 
         # Try to update the article with right user
+        respo1 = client.put(
+            my_url,
+            update_input,
+            **self.header_user1,
+            format='json'
+        )
+        self.assertEqual(respo1.status_code, status.HTTP_200_OK)
+
+        #Update without taglist
+        update_input = {
+            "article": {
+                "title": "The PR raisers",
+            }
+        }
         respo1 = client.put(
             my_url,
             update_input,
@@ -251,7 +267,7 @@ class ArticleViewsTestCase(TestCase):
         self.assertEqual(respo.status_code, status.HTTP_201_CREATED)
 
         # Publish article of user1
-        my_url = '/api/articles/{}/edit'.format(respo.data['slug'])
+        my_url = '/api/articles/{}/publish/'.format(respo.data['slug'])
         respo1 = client.patch(
             my_url,
             **self.header_user1,

--- a/authors/apps/articles/tests/test_comment_views.py
+++ b/authors/apps/articles/tests/test_comment_views.py
@@ -19,7 +19,7 @@ class CommentListCreateViewTest(TestCase):
 
     def setUp(self):
         self.user1 = UserFactory.create()
-        self.article = ArticleFactory.create(author=self.user1)
+        self.article = ArticleFactory.create(author=self.user1.profile)
         self.factory = APIRequestFactory()
 
     def test_author_can_create_article_comments(self):
@@ -88,7 +88,7 @@ class CommentListCreateViewTest(TestCase):
                                                     username="bob")
         user.is_verified = True
         user.save()
-        article = ArticleFactory.create(author=user)
+        article = ArticleFactory.create(author=user.profile)
         comment = ThreadedComment.objects.create(author=user.profile,
                                                article=article)
         client = APIClient()

--- a/authors/apps/articles/tests/test_favorite_articles.py
+++ b/authors/apps/articles/tests/test_favorite_articles.py
@@ -45,7 +45,7 @@ class FavoriteArticleTestCase(ArticlesBaseTest):
         """Test get favorites endpoint"""
         self.client.post(self.favorite_article_url, **self.header_user1)
 
-        response = self.client.get('/api/articles/favorites/',
+        response = self.client.get('/api/articles/user/favorites/',
                                    **self.header_user1)
         self.assertEqual(len(response.data.get('favorites')), 1)
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/authors/apps/articles/tests/test_managers.py
+++ b/authors/apps/articles/tests/test_managers.py
@@ -12,8 +12,8 @@ class  CommentActiveObjectsManagerTests(TestCase):
     def setUp(self):
         self.user1 = UserFactory.create()
         self.user2 = UserFactory.create()
-        self.article1 = ArticleFactory.create(author=self.user1)
-        self.article2 = ArticleFactory.create(author=self.user2)
+        self.article1 = ArticleFactory.create(author=self.user1.profile)
+        self.article2 = ArticleFactory.create(author=self.user2.profile)
 
     def test_fetching_only_active_comments(self):
         comment1 = ThreadedComment.objects.create(author=self.user1.profile,

--- a/authors/apps/articles/tests/test_models.py
+++ b/authors/apps/articles/tests/test_models.py
@@ -10,7 +10,7 @@ class CommentMethodTests(TestCase):
 
     def setUp(self):
         self.user1 = UserFactory.create()
-        self.article1 = ArticleFactory.create(author=self.user1)
+        self.article1 = ArticleFactory.create(author=self.user1.profile)
 
     def test_comment_string_representation(self):
         body = "comments and stuff "
@@ -40,7 +40,7 @@ class CommentSnapshotSignalTests(TestCase):
 
     def setUp(self):
         self.user1 = UserFactory.create()
-        self.article1 = ArticleFactory.create(author=self.user1)
+        self.article1 = ArticleFactory.create(author=self.user1.profile)
 
     def test_snapshot_is_saved_only_when_a_comment_is_edited(self):
         body = "testing comment"

--- a/authors/apps/articles/tests/test_models_vol1.py
+++ b/authors/apps/articles/tests/test_models_vol1.py
@@ -2,6 +2,7 @@ from django.test import TestCase
 
 from authors.apps.articles.models import Tag, Article
 from authors.apps.authentication.models import User
+from authors.apps.articles.serializers import TheArticleSerializer
 
 class ArticleModelTestCase(TestCase):
 
@@ -14,7 +15,7 @@ class ArticleModelTestCase(TestCase):
         self.article_one = Article.objects.create(
             title = "I am the OG",
             body = "This is an article by the OG",
-            author = self.user_one
+            author = self.user_one.profile
         )
 
     def test_article_creation(self):
@@ -36,7 +37,7 @@ class  TagModelTestCase(TestCase):
         self.article_one = Article.objects.create(
             title = "I am the OG",
             body = "This is an article by the OG",
-            author = self.user_one
+            author = self.user_one.profile
         )
 
     def test_tag_creation(self):

--- a/authors/apps/articles/tests/test_renderers.py
+++ b/authors/apps/articles/tests/test_renderers.py
@@ -16,7 +16,7 @@ class CommentRendererTest(TestCase):
 
     def setUp(self):
         self.user1 = UserFactory.create()
-        self.article1 = ArticleFactory.create(author=self.user1)
+        self.article1 = ArticleFactory.create(author=self.user1.profile)
         self.factory = APIRequestFactory()
 
     def test_comment_json_renderer(self):

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,18 +1,18 @@
 from . import views
 from django.urls import path
 
-
 app_name = 'articles'
 
-
 urlpatterns = [
-    path('create', views.CreateArticleView.as_view(),
+    path('create/', views.CreateArticleView.as_view(),
          name="create_article"),
     path('', views.GetArticlesView.as_view(), name="get_article"),
-    path('<slug:slug>', views.GetAnArticleView.as_view(),
+    path('<slug:slug>/', views.GetAnArticleView.as_view(),
          name="get_an_article"),
-    path('<slug:slug>/edit', views.UpdateAnArticleView.as_view(),
+    path('<slug:slug>/edit/', views.UpdateAnArticleView.as_view(),
          name="update_an_article"),
+    path('<slug:slug>/publish/', views.PublishAnArticleView.as_view(),
+         name="publish_an_article"),
     path('<slug:slug>/like/', views.CreateRetrieveLikeView.as_view(),
          name="create_like"),
     path('<slug:slug>/like/<int:pk>/', views.UpdateDeleteLikeView.as_view(),
@@ -30,10 +30,8 @@ urlpatterns = [
     path('<slug:slug>/favorite/',
          views.FavoriteView.as_view(), name="favorite"),
 
-    path('favorites/',
+    path('user/favorites/',
          views.GetUserFavoritesView.as_view(), name="get_favorites"),
-    path('<slug:slug>/likes/',
-         views.GetArticleLikesView.as_view(), name="get_likes"),
     path('<slug:slug>/rate/',
          views.RatingView.as_view(), name="rate"),
     path('<slug:slug>/ratings/',

--- a/authors/apps/articles/utils.py
+++ b/authors/apps/articles/utils.py
@@ -1,4 +1,6 @@
 from django.utils.text import slugify
+from rest_framework.response import Response
+from rest_framework import status
 
 
 def generate_unique_slug(model_instance, slugable_field_name, slug_field_name):
@@ -19,3 +21,44 @@ def generate_unique_slug(model_instance, slugable_field_name, slug_field_name):
         extension += 1
 
     return unique_slug
+
+
+def edit_article(instance, request, the_data, tag_instance=None):
+    if instance.get_object().author.user.username == request.user.username:
+        if instance.get_object().activated is False:
+            invalid_entry = {
+                "detail": "This article does not exist."
+            }
+            return Response(
+                invalid_entry,
+                status=status.HTTP_404_NOT_FOUND
+            )
+
+        article_obj = instance.get_object()
+        serialized = instance.serializer_class(
+            article_obj, data=the_data, partial=True,
+            context={"current_user": request.user}
+        )
+        serialized.is_valid(raise_exception=True)
+        instance.perform_update(serialized)
+        if "activated" in the_data.keys()\
+                and the_data["activated"] is False:
+            deleted_entry = {
+                "detail": "This article has been deleted."
+            }
+            return Response(
+                deleted_entry,
+                status=status.HTTP_200_OK
+            )
+        return Response(
+            serialized.data,
+            status=status.HTTP_200_OK
+        )
+
+    not_found = {
+        "detail": "You are not the owner of the article."
+    }
+    return Response(
+        not_found,
+        status=status.HTTP_401_UNAUTHORIZED
+    )


### PR DESCRIPTION
**Description**

<hr>
This PR handles feedback of article module given by the team, TTL and PO. The features captured in this PR
include:

- Change the endpoint of publish to terminate with the word publish

```
		/articles/<slug:slug>/publish/
```

- Refactor code to remove changing slugs on article title update.
- Refactor code to add all profile fields under author when fetching an article.
- Appended a slash at the end of each line in the articles module.

```
		/articles/<slug:slug>/publish/
		/articles/<slug:slug>/edit/
		/articles/create/
```


**Type of change**

<hr>

- [x] Implement  feedback on article module


**How has this been tested**
<hr>

- [x] End to End
- [x] Integration


**Checklist:**
<hr>

- [x] Change the endpoint of publish to terminate with the word publish
- [x] Refactor code to remove changing slugs on article title update.
- [x] Refactor code to add all profile fields under author when fetching an article.
- [x] Appended a slash at the end of each line in the articles module.


**Related Stories**
<hr>

[Fix article outputs](https://www.pivotaltracker.com/n/projects/2313280/stories/164753579)