### PR TITLE
#164851954 Users Get Articles by Specific Author

### DIFF
--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -1,7 +1,7 @@
 import json
 
 from rest_framework.renderers import JSONRenderer
-from rest_framework.utils.serializer_helpers import ReturnDict
+from rest_framework.utils.serializer_helpers import ReturnDict, ReturnList
 
 from ..articles.models import Tag
 
@@ -26,6 +26,10 @@ class ArticleJSONRenderer(JSONRenderer):
             my_data = self._single_article_formatting(data)
             return json.dumps({
                 'Article': my_data
+            })
+        elif type(data) is ReturnList:
+            return json.dumps({
+                'Articles': data
             })
         else:
             # many articles

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -169,3 +169,25 @@ class BookmarkSerializer(serializers.ModelSerializer):
         model = Bookmark
         fields = ('id', 'user_id', 'article_id')
         read_only_fields = ['id']
+
+
+class PersonalArticlesSerializer(serializers.ModelSerializer):
+    """
+    separate serilizer for getting all
+    articles belonging to logged in user
+    no need of 'author' field since
+    they all belong to the currently logged in user.
+    """
+
+    reading_time = serializers.ReadOnlyField(source='get_reading_time')
+    average_rating = serializers.ReadOnlyField(source='get_average_rating')
+
+    class Meta:
+        model = Article
+        fields = [
+            'id', 'title', 'body', 'draft', 'slug',
+            'reading_time', 'average_rating', 'tags',
+            'editing', 'description', 'published', 'activated',
+            "created_at", "updated_at"
+        ]
+        read_only_fields = ['slug']

--- a/authors/apps/articles/tests/test_article_views.py
+++ b/authors/apps/articles/tests/test_article_views.py
@@ -262,16 +262,37 @@ class ArticleViewsTestCase(TestCase):
         }
         # Create article with user1
         client = APIClient()
-        respo = client.post(reverse('articles:create_article'),
+        response = client.post(reverse('articles:create_article'),
                             sample_input, **self.header_user1, format='json')
-        self.assertEqual(respo.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Publish article of user1
-        my_url = '/api/articles/{}/publish/'.format(respo.data['slug'])
+        my_url = '/api/articles/{}/publish/'.format(response.data['slug'])
         respo1 = client.patch(
             my_url,
             **self.header_user1,
             format='json'
         )
         self.assertEqual(respo1.status_code, status.HTTP_400_BAD_REQUEST)
+    
+    def test_get_articles_by_author(self):
+        client = APIClient()
+        my_url = '/api/profiles/{}/articles/'.format("user1")
+        response = client.get(my_url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
+    
+    def test_get_articles_by_non_existent_author(self):
+        client = APIClient()
+        my_url = '/api/profiles/{}/articles/'.format("user89")
+        response = client.get(my_url, **self.header_user1,)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()['Articles']['detail'], "The requested profile does not exist.")
+    
+    def test_get_articles_for_currently_logged_in_user(self):
+        client = APIClient()
+        my_url = '/api/user/articles/'
+        response = client.get(my_url, **self.header_user1,)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -14,7 +14,8 @@ from .serializers import (ArticleCommentInputSerializer,
                           TheArticleSerializer,
                           ThreadedCommentOutputSerializer,
                           FavoriteSerializer, RatingSerializer,
-                          ArticleRatingSerializer, BookmarkSerializer)
+                          ArticleRatingSerializer, BookmarkSerializer,
+                          PersonalArticlesSerializer)
 from .models import (Article, Bookmark, Like,
                      ThreadedComment, Favorite, Rating, Tag)
 from authors.apps.core.views import BaseManageView
@@ -50,6 +51,22 @@ class CreateArticleView(mixins.CreateModelMixin,
         serializer.is_valid(raise_exception=True)
         serializer.save()
         return Response(serializer.data, status=status.HTTP_201_CREATED)
+
+
+class GetAllArticlesForCurrentUser(generics.ListAPIView):
+
+    permission_classes = (IsAuthenticated,)
+    renderer_classes = (ArticleJSONRenderer,)
+    serializer_class = PersonalArticlesSerializer
+
+    def get(self, request):
+        """ get method for seeing all articles belonging to logged in user """
+        user = request.user
+        all_user_articles = user.profile.articles.all()
+        serializer = self.serializer_class(
+            all_user_articles, many=True
+        )
+        return Response(serializer.data, status=status.HTTP_200_OK)
 
 
 class GetArticlesView(mixins.ListModelMixin, generics.GenericAPIView):

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -4,6 +4,7 @@ from .views import (LoginAPIView, RegistrationAPIView,
                     UserRetrieveUpdateAPIView, SocialAuthenticationView,
                     EmailVerificationView, CreateEmailVerificationTokenAPIView,
                     PasswordResetView)
+from ..articles.views import GetAllArticlesForCurrentUser
 
 
 app_name = 'authentication'
@@ -20,5 +21,7 @@ urlpatterns = [
     path('token/', CreateEmailVerificationTokenAPIView.as_view(),
          name='new verification token'),
     path('password-reset/', PasswordResetView.as_view(),
-         name='password-reset')
+         name='password-reset'),
+    path('articles/', GetAllArticlesForCurrentUser.as_view(),
+         name='personal-articles'),
 ]

--- a/authors/apps/profiles/urls.py
+++ b/authors/apps/profiles/urls.py
@@ -2,7 +2,8 @@ from django.urls import path
 
 from .views import (
     ProfileRetrieveAPIView, ProfilesListAPIView,
-    FollowUnfollowAPIView, FollowerFollowingAPIView)
+    FollowUnfollowAPIView, FollowerFollowingAPIView,
+    GetArticlesByAuthor)
 
 app_name = 'profiles'
 
@@ -13,5 +14,7 @@ urlpatterns = [
          FollowUnfollowAPIView.as_view(), name='follow-unfollow'),
     path('<str:username>/following/',
          FollowerFollowingAPIView.as_view(), name="following"),
+    path('<str:username>/articles/',
+         GetArticlesByAuthor.as_view(), name="articles"),
     path('', ProfilesListAPIView.as_view(), name='profiles'),
 ]


### PR DESCRIPTION
### What does this PR do?
1. Enable readers to get all articles by a specific user
2. Enable authors to get all articles they own.


### Description
Users should get articles by author, this will act as a starting point for authors after logging in to the app and eventually to their profiles, under their dashboards, they would get a list of all articles they have written, published or not.
Other users should also be able to view all articles written by a specific user, however, they will be able to see only published articles.

 -  [x] Readers see published articles by author
 -  [x] Authors view all their articles, published or not


### How has this been tested?
 - [x] Unit tests
 - [x] Integration tests

### Documentation
The following endpoints added to the application. Note that you will not be required to add any input for all the endpoints, simply access the endpoints with a logged in user.

```
GET /api/user/articles/ - Get all articles for logged in user
GET /api/profiles/<username>/articles/ - Users get to see all published articles for a specific author

```

### Changelog and what to work on next.
 - [x] Pagination for the returned articles.


### PT.
[#164851954](https://www.pivotaltracker.com/story/show/164851954)