### PR TITLE
[164046264] Articles can be shared on social media

### DIFF
--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -4,6 +4,7 @@ from authors.apps.profiles.serializers import ProfileSerializer
 from authors.apps.profiles.models import Profile
 from .models import (Article, Favorite, Like, Snapshot,
                      ThreadedComment, Rating, Tag)
+from authors.apps.core.utils import share_link_generator
 
 
 class TheArticleSerializer(serializers.ModelSerializer):
@@ -11,6 +12,7 @@ class TheArticleSerializer(serializers.ModelSerializer):
     reading_time = serializers.ReadOnlyField(source='get_reading_time')
     average_rating = serializers.ReadOnlyField(source='get_average_rating')
     author = ProfileSerializer(read_only=True)
+    share_links = serializers.SerializerMethodField()
 
     class Meta:
         model = Article
@@ -18,7 +20,7 @@ class TheArticleSerializer(serializers.ModelSerializer):
             'id', 'title', 'body', 'draft', 'slug',
             'reading_time', 'average_rating', 'tags',
             'editing', 'description', 'published', 'activated',
-            "created_at", "updated_at", 'author'
+            "created_at", "updated_at", 'author', 'share_links',
         ]
         read_only_fields = ['slug']
 
@@ -67,6 +69,9 @@ class TheArticleSerializer(serializers.ModelSerializer):
 
         instance.save()
         return instance
+
+    def get_share_links(self, instance):
+        return share_link_generator(instance, self.context['request'])
 
 
 class LikesSerializer(serializers.ModelSerializer):

--- a/authors/apps/articles/utils.py
+++ b/authors/apps/articles/utils.py
@@ -37,7 +37,7 @@ def edit_article(instance, request, the_data, tag_instance=None):
         article_obj = instance.get_object()
         serialized = instance.serializer_class(
             article_obj, data=the_data, partial=True,
-            context={"current_user": request.user}
+            context={"current_user": request.user, "request": request}
         )
         serialized.is_valid(raise_exception=True)
         instance.perform_update(serialized)

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -43,7 +43,9 @@ class CreateArticleView(mixins.CreateModelMixin,
 
         # Decode token
         serializer = TheArticleSerializer(
-            data=payload, context={"current_user": request.user}
+            data=payload, context={
+                "current_user": request.user,
+                "request": request}
         )
         serializer.is_valid(raise_exception=True)
         serializer.save()
@@ -77,7 +79,7 @@ class GetArticlesView(mixins.ListModelMixin, generics.GenericAPIView):
 
         serializer = self.serializer_class(
             page, many=True,
-            context={"current_user": request.user}
+            context={"current_user": request.user, "request": request}
         )
         return paginator.get_paginated_response(serializer.data)
 
@@ -98,7 +100,9 @@ class GetAnArticleView(mixins.RetrieveModelMixin,
 
         if found_article is not None:
             serialized = self.serializer_class(
-                found_article, context={"current_user": request.user}
+                found_article, context={
+                    "current_user": request.user,
+                    "request": request}
             )
             return Response(
                 serialized.data,
@@ -499,7 +503,7 @@ class GetUserFavoritesView(APIView):
         for favorite in favorites_queryset:
             article = TheArticleSerializer(
                 favorite.article_id,
-                context={"current_user": request.user}
+                context={"current_user": request.user, "request": request}
             ).data
             favorite_articles.append(article)
         favorites = {
@@ -533,7 +537,7 @@ class RatingView(APIView):
             if user_id == request.user.id:
 
                 return Response({"message":
-                                "You cannot rate your own article."},
+                                 "You cannot rate your own article."},
                                 status=status.HTTP_403_FORBIDDEN
                                 )
             else:
@@ -548,7 +552,7 @@ class RatingView(APIView):
             serializer.is_valid(raise_exception=True)
             serializer.save()
             return Response({"message":
-                            "Article rated."},
+                             "Article rated."},
                             status=status.HTTP_201_CREATED)
 
         except Article.DoesNotExist:

--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -680,7 +680,8 @@ class GetUserBookmarksView(APIView):
         bookmarked_articles = []
         for bookmark in bookmarks_queryset:
             article = TheArticleSerializer(bookmark.article_id, context={
-                                           "current_user": request.user}).data
+                                           "current_user": request.user,
+                                           "request": request}).data
             bookmarked_articles.append(article)
         bookmarks = {
             "bookmarks": bookmarked_articles

--- a/authors/apps/core/utils.py
+++ b/authors/apps/core/utils.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+from urllib import parse
 
 import jwt
 
@@ -8,6 +9,7 @@ from rest_framework import exceptions
 
 from django.core.mail import EmailMessage
 from django.template.loader import render_to_string
+from django.urls import reverse
 
 
 class TokenHandler:
@@ -68,3 +70,26 @@ class TokenHandler:
         msg.content_subtype = 'html'
         msg.send()
 
+
+def share_link_generator(instance, request):
+    """
+    This method takes an article instance and a request to create a
+    sharable link to the article.
+    """
+    links = {}
+
+    article_title = instance.title
+    article_link = request.build_absolute_uri(
+        reverse('articles:get_an_article', kwargs={'slug': instance.slug}))
+
+    valid_article_link = parse.quote(article_link)
+    valid_article_title = parse.quote(article_title)
+
+    links['email'] = 'mailto:?&subject=' + valid_article_title + '&body='\
+        + valid_article_title + '%0A%0A' + valid_article_link
+    links['facebook'] = 'https://www.facebook.com/sharer/sharer.php?u='\
+                        + valid_article_link
+    links['twitter'] = 'https://twitter.com/home?status=' + valid_article_link
+    links['google'] = 'https://plus.google.com/share?url=' + valid_article_link
+
+    return links


### PR DESCRIPTION
### What does this PR do?
Add links for sharing articles via social media.

### Description
Users should be able to share articles via social media. This is important for enabling authors reach a wider audience on their articles. Email links are also supported.

###### Social medias sites covered
- [x] Facebook
- [x] Twitter
- [x] Google
- [x] Email

### How has this been tested?
 - [x] N/A ... It has been tested by all previous tests for articles

### How can this be manually tested?
Make any request that returns an article or list of articles. You will notice a new key included called `share_links` that has the links for sharing on social media channels.

### PT
[#164046264](https://www.pivotaltracker.com/story/show/164046264)