### PR TITLE
#165117092: Asynchronous Sending of Registration Email.

### DIFF
--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -22,7 +22,7 @@ from .serializers import (LoginSerializer, RegistrationSerializer,
                           PasswordResetSerializer, PasswordResetTokenSerializer)
 from .utils import validate_image
 from authors.apps.core.utils import TokenHandler
-
+from threading import Thread
 from .models import User, PasswordResetToken
 
 
@@ -60,10 +60,16 @@ class RegistrationAPIView(APIView):
         # https://stackoverflow.com/questions/3005080/how-to-send-html-email-with-django-with-dynamic-content-in-it
         html_message = render_to_string(template_name, context)
         text_message = strip_tags(html_message)
-        mail.send_mail(
-            'Please verify your email',
-            text_message, settings.FROM_EMAIL,
-            [user_email, ], html_message=html_message)
+        thread = Thread(
+            target=mail.send_mail, args=[
+                'Please verify your email',
+                text_message,
+                settings.FROM_EMAIL,
+                [user_email, ],
+                html_message]
+        )
+        thread.setDaemon(True)
+        thread.start()
 
         message = {
             'message': 'Successfully created your account. Please proceed to your email ' + # noqa
@@ -278,10 +284,16 @@ class CreateEmailVerificationTokenAPIView(APIView):
                    'token': token, 'domain': domain}
         html_message = render_to_string(template_name, context)
         text_message = strip_tags(html_message)
-        mail.send_mail(
-            'Please verify your email',
-            text_message, settings.FROM_EMAIL,
-            [user_email, ], html_message=html_message)
+        thread = Thread(
+            target=mail.send_mail, args=[
+                'Please verify your email',
+                text_message,
+                settings.FROM_EMAIL,
+                [user_email, ],
+                html_message]
+        )
+        thread.setDaemon(True)
+        thread.start()
 
         message = {'message': 'New verification token created. Please proceed to your email ' + # noqa
                    user_email + ' to verify your account.'}


### PR DESCRIPTION
### What does this PR do?
Allows sending of email asynchronously after successful registration

### Description
Currently, after successful user registration, mail sending slows down the app by 5-10 seconds. This PR reduces the time to 0.05 seconds because mail_sending happens on a separate thread.

### How has this been tested?
 - [x] N/A 

### How can this be manually tested?
Try registering a user

### PT
##165117092](https://www.pivotaltracker.com/story/show/##165117092)