### PR TITLE
#165193798 JWT token expires after 1 year

### DIFF
--- a/authors/apps/authentication/models.py
+++ b/authors/apps/authentication/models.py
@@ -136,7 +136,7 @@ class User(AbstractBaseUser, PermissionsMixin):
         We generate JWT token and add the user id, username and expiration
         as an integer.
         """
-        token_expiry = datetime.now() + timedelta(hours=2)
+        token_expiry = datetime.now() + timedelta(days=365)
 
         token = jwt.encode({
             'id': self.pk,


### PR DESCRIPTION
### What does this PR do?
Set the JWT token to expire after one year
### Description
Because we don't have an endpoint for getting a refresh token, JWT tokens might expire too soon even while users are still logged in. To fix this, we set the tokens to expire after a long time.

### How has this been tested?
 - [x] N/A. Everything should work same as before

### Checklist
- [x] Code standards met

###  PT
[#165193798](https://www.pivotaltracker.com/story/show/165193798)
