### PR TITLE
#165485642 Users Get User Details After un/following another user.

### DIFF
--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -88,10 +88,15 @@ class FollowUnfollowAPIView(APIView):
         request.user.profile.followings.add(to_be_followed)
         request.user.save()
 
+        profile_serializer = ProfileSerializer(
+            to_be_followed, context={'current_user': request.user})
+
         serializer = FollowUnfollowSerializer(request.user.profile)
         message = {
             "message": f"You are now following {username}",
-            "user": serializer.data
+            "current_user": serializer.data,
+            "user_of_interest": profile_serializer.data
+
         }
         return Response(message, status=status.HTTP_200_OK)
 
@@ -120,10 +125,14 @@ class FollowUnfollowAPIView(APIView):
         request.user.profile.followings.remove(to_be_unfollowed)
         request.user.save()
 
+        profile_serializer = ProfileSerializer(
+            to_be_unfollowed, context={'current_user': request.user})
+
         serializer = FollowUnfollowSerializer(request.user.profile)
         message = {
             "message": f"You just unfollowed {username}",
-            "user": serializer.data
+            "curent_user": serializer.data,
+            "user_of_interest": profile_serializer.data,
         }
         return Response(message, status=status.HTTP_200_OK)
 


### PR DESCRIPTION
### What does this PR do?
This enables users to get details of the user they recently followed/unfollowed.

#### Type of change

- [x] Non-breaking change that adds a micro-feature.

#### How Has This Been Tested?
- [x] Unit tests

#### Before 
<img width="404" alt="Screenshot 2019-04-21 at 19 56 43" src="https://user-images.githubusercontent.com/44457835/56473158-be65c980-646f-11e9-9f7f-2f43dc3fdef2.png">

#### After
<img width="949" alt="Screenshot 2019-04-21 at 19 55 47" src="https://user-images.githubusercontent.com/44457835/56473152-b574f800-646f-11e9-9452-47f75acafcc5.png">

#### PT
[#165485642](https://www.pivotaltracker.com/story/show/165485642)