### PR TITLE
#164046269  Users Can like Comments

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -108,6 +108,10 @@ class ThreadedComment(TimeStamped):
         """Return whether the comment has been edited."""
         return self.snapshots.all().exists()
 
+    @property
+    def total_likes(self):
+        return self.likes.count()
+
 
 class Snapshot(models.Model):
     """Model to take snapshots of comments everytime they are edited."""
@@ -129,3 +133,16 @@ class Favorite(models.Model):
         related_name='favorites')
     article_id = models.ForeignKey(
         Article, on_delete=models.CASCADE, related_name='favorites')
+
+
+class CommentLike(models.Model):
+    """A like of a comment model."""
+    created_at = models.DateTimeField(auto_now_add=True)
+    user = models.ForeignKey(settings.AUTH_USER_MODEL,
+                             related_name="comment_likes",
+                             on_delete=models.CASCADE)
+    comment = models.ForeignKey('ThreadedComment', related_name="likes",
+                                on_delete=models.CASCADE)
+
+    class Meta:
+        unique_together = ('comment', 'user')

--- a/authors/apps/articles/tests/test_models.py
+++ b/authors/apps/articles/tests/test_models.py
@@ -3,7 +3,7 @@ from django.test import TestCase
 from authors.apps.core.factories import UserFactory
 
 from ..factories import ArticleFactory
-from ..models import Snapshot, ThreadedComment
+from ..models import CommentLike, Snapshot, ThreadedComment
 
 
 class CommentMethodTests(TestCase):
@@ -34,6 +34,14 @@ class CommentMethodTests(TestCase):
         self.assertEqual(comment.is_active, False)
         comment.undo_soft_deletion()
         self.assertEqual(comment.is_active, True)
+
+    def test_getting_count_of_likes_on_a_comment(self):
+        comment = ThreadedComment.objects.create(author=self.user1.profile,
+                                        article=self.article1)
+        self.assertEqual(comment.total_likes, 0)
+        like = CommentLike.objects.create(user=self.user1, comment=comment)
+        like.save()
+        self.assertEqual(comment.total_likes, 1)
 
 
 class CommentSnapshotSignalTests(TestCase):

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,5 +1,7 @@
-from . import views
 from django.urls import path
+
+from . import views
+
 
 app_name = 'articles'
 
@@ -23,6 +25,9 @@ urlpatterns = [
     path('<slug:article_slug>/comments/<pk>/',
          views.CommentRetrieveEditDeleteView.as_view(),
          name="comment"),
+    path('<slug:article_slug>/comments/<pk>/likes/',
+         views.CommentLikeCreateDeleteView.as_view(),
+         name="comment_likes"),
     path('<slug:slug>/likes/',
          views.GetArticleLikesView.as_view(), name="get_likes"),
 


### PR DESCRIPTION
#### DescriptionA
Adds the ability to like comments and unlike comments that they already like.

#### Type of change

- [x] Non-breaking change (likes and unlike liked comments)

#### How Has This Been Tested?
- [x] Unit Tests

#### Checklist:
- [x] Feature passes team flake8 standards

### How can this be manually tested?
- Follow instructions on the README page and set up your environment locally.
- Make a **PUT** request on the URL `/api/articles/<slug>/comments/likes/` to like an article
- Make a **DELETE** request on the URL `/api/articles/<slug>/comments/likes/` to unlike an article


#### PT
[#164046269](https://www.pivotaltracker.com/story/show/164046269)