### PR TITLE
feature(#164046262): Users should be able to search for articles

### DIFF
--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -62,3 +62,15 @@ class ReportJSONRenderer(JSONRenderer):
             'report_details': data
 
         })
+
+
+class SearchJSONRenderer(JSONRenderer):
+    '''Returns results from a search of articles'''
+    charset = 'utf-8'
+    article_formatting = ArticleJSONRenderer()
+
+    def render(self, data, media_type=None, renderer_context=None):
+        if "articles" in data.keys():
+            for item in data["articles"]:
+                item = self.article_formatting._single_article_formatting(item)
+        return json.dumps(data)

--- a/authors/apps/articles/tests/test_article_views.py
+++ b/authors/apps/articles/tests/test_article_views.py
@@ -349,3 +349,73 @@ class ArticleViewsTestCase(TestCase):
             'articles:get-all-reports'),**self.header_user1)
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    def test_search_for_article(self):
+        # Create article with user1
+        client = APIClient()
+        respo = client.post(reverse('articles:create_article'),
+                            self.sample_input, **self.header_user1, format='json')
+        self.assertEqual(respo.status_code, status.HTTP_201_CREATED)
+
+        # Publish article of user1
+        my_url = '/api/articles/{}/publish/'.format(respo.data['slug'])
+        respo1 = client.patch(
+            my_url,
+            **self.header_user1,
+            format='json'
+        )
+        self.assertEqual(respo1.status_code, status.HTTP_200_OK)
+
+        # Search for an article
+        test_data = {
+            "search_string": "o"
+        }
+        response = client.put(reverse('articles:search-article'),
+                               test_data, **self.header_user1, format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        response = client.put(reverse('articles:search-article'),
+                               **self.header_user1, format='json')
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        my_url = '/api/articles/user/search/?query=tags,author,title,description,body'
+        respo1 = client.put(
+            my_url,
+            test_data,
+            format='json',
+        )
+        self.assertEqual(respo1.status_code, status.HTTP_200_OK)
+        my_url = '/api/articles/user/search/?query=tags'
+        respo1 = client.put(
+            my_url,
+            test_data,
+            format='json',
+        )
+        self.assertEqual(respo1.status_code, status.HTTP_200_OK)
+        my_url = '/api/articles/user/search/?query=author'
+        respo1 = client.put(
+            my_url,
+            test_data,
+            format='json',
+        )
+        self.assertEqual(respo1.status_code, status.HTTP_200_OK)
+        my_url = '/api/articles/user/search/?query=title'
+        respo1 = client.put(
+            my_url,
+            test_data,
+            format='json',
+        )
+        self.assertEqual(respo1.status_code, status.HTTP_200_OK)
+        my_url = '/api/articles/user/search/?query=description'
+        respo1 = client.put(
+            my_url,
+            test_data,
+            format='json',
+        )
+        self.assertEqual(respo1.status_code, status.HTTP_200_OK)
+        my_url = '/api/articles/user/search/?query=body'
+        respo1 = client.put(
+            my_url,
+            test_data,
+            format='json',
+        )
+        self.assertEqual(respo1.status_code, status.HTTP_200_OK)
+

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -43,4 +43,6 @@ urlpatterns = [
          views.GetUserBookmarksView.as_view(), name="get_bookmarks"),
     path('<slug:slug>/report/',
          views.ReportAnArticle.as_view(), name="report-article"),
+    path('user/search/',
+         views.SearchForArticles.as_view(), name="search-article"),
 ]


### PR DESCRIPTION
**Description**
<hr>

This PR adds custom filtering and search functionality. A user can be able to perform partial and full word searches depending on the `search string` he/she wants to search. This feature also enables the user to filter his/her search depending on the specific fields he/she wants to search. Currently, the fields that the user can search from are `author`, `tags`, `title`, `description` and  `body`. In order for a user to search, he/she should use the following endpoint:

`PUT /api/articles/user/search/ - Searches for all articles with the given search string`

For the data pass the following dictionary and set `value` to be your search string:

`{"search_string":  <value>}`

To filter by field the URL is as shown below, for the fields listed above:

`PUT /api/articles/user/search/?query=tags - Filters for all articles with the given search string in the tag_list attribute`

To filter multiple fields at the same time add the fields separated by commas as shown below:

`PUT /api/articles/user/search/?query=tags,author,body,description - Filters for all articles with the given search string in the tag_list attribute`

**Type of Change**
<hr>

- [x] feature(a breaking change that allows users to search and filter the articles that they may want).

**Checklist**
<hr>

- [x] Users should be able to search for articles.
- [x] Users should be able to filter	 articles according to the different fields
- [x] Add tests to show search functionality.

**Related Stories**
<hr> 

[Add search functionality and custom filtering](https://www.pivotaltracker.com/n/projects/2313280/stories/164046262)