### PR TITLE
bug(liking functionality): Users should be able to see all article likes/dislikes

### DIFF
--- a/authors/apps/articles/tests/article_tests_base_class.py
+++ b/authors/apps/articles/tests/article_tests_base_class.py
@@ -39,6 +39,7 @@ class ArticlesBaseTest(APITestCase):
         retrieved_article.published = True
         retrieved_article.save()
         self.like_article_url = '/api/articles/{}/like/'.format(self.slug)
+        self.all_article_likes_url = '/api/articles/{}/all-likes/'.format(self.slug)
         self.favorite_article_url = '/api/articles/{}/favorite/'.format(self.slug)
         self.get_favorites_url = reverse('articles:get_favorites')
         self.rate_url = '/api/articles/{}/rate/'.format(self.slug)

--- a/authors/apps/articles/tests/test_like_dislike_article.py
+++ b/authors/apps/articles/tests/test_like_dislike_article.py
@@ -29,7 +29,9 @@ class LikeDislikeArticleTestCase(ArticlesBaseTest):
         """Test like"""
         response = self.client.get(self.like_article_url,
                                    **self.header_user1)
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        detail = "undefined"
+        self.assertEqual(response.data.get("is_like"), detail)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         self.client.post(self.like_article_url,
                          like_data, **self.header_user1, format='json')
@@ -41,6 +43,18 @@ class LikeDislikeArticleTestCase(ArticlesBaseTest):
                                    **self.header_user1)
         detail = "This article has not been found."
         self.assertEqual(response.data.get('detail'), detail)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_get_all_likes(self):
+        """Test get all likes"""
+        self.client.post(self.like_article_url,
+                         like_data, **self.header_user1, format='json')
+        response1 = self.client.get(
+            self.all_article_likes_url, **self.header_user1)
+        self.assertEqual(response1.status_code, status.HTTP_200_OK)
+        # Test invalid slug
+        response = self.client.get('/api/articles/invalid-slug/all-likes/',
+                                   **self.header_user1)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_update_like(self):

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -28,6 +28,8 @@ urlpatterns = [
          name="comment"),
     path('<slug:slug>/likes/',
          views.GetArticleLikesView.as_view(), name="get_likes"),
+    path('<slug:slug>/all-likes/',
+         views.GetAllLikesView.as_view(), name="get_all_likes"),
     path('<slug:slug>/favorite/',
          views.FavoriteView.as_view(), name="favorite"),
 


### PR DESCRIPTION
**Description**
<hr/>

This PR fixes bugs in the liking feature that is essential for the running of this feature in the frontend. Currently, when a user tries to access his/her like details of an article, it does not come with the like status hence one cannot know if the user has liked or unliked the article. Also, the like functionality as is currently implemented does not have an endpoint where we could view all likes and dislikes of an article which is a major thing that should be included in this feature.

**Type of Change**
<hr/>

- [x] feature(a non-breaking change that allows users to get all likes/dislikes of an article).

**Checklist**
<hr/>

- [x] Users should be able to see whether they have liked/disliked an article
- [x] Users should be able to see all article likes/dislikes
- [x] Add tests to show the like fix functionality.

**Related Stories**
<hr/>

[Add search functionality and custom filtering](https://www.pivotaltracker.com/n/projects/2313280/stories/165900489)