### PR TITLE
bug(#165963466): Customising data representation in the search functionality

### DIFF
--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -70,7 +70,7 @@ class SearchJSONRenderer(JSONRenderer):
     article_formatting = ArticleJSONRenderer()
 
     def render(self, data, media_type=None, renderer_context=None):
-        if "articles" in data.keys():
-            for item in data["articles"]:
+        if "results" in data.keys():
+            for item in data["results"]:
                 item = self.article_formatting._single_article_formatting(item)
         return json.dumps(data)

--- a/authors/apps/articles/tests/test_article_views.py
+++ b/authors/apps/articles/tests/test_article_views.py
@@ -365,57 +365,45 @@ class ArticleViewsTestCase(TestCase):
         )
         self.assertEqual(respo1.status_code, status.HTTP_200_OK)
 
-        # Search for an article
-        test_data = {
-            "search_string": "o"
-        }
-        response = client.put(reverse('articles:search-article'),
-                               test_data, **self.header_user1, format='json')
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        response = client.put(reverse('articles:search-article'),
-                               **self.header_user1, format='json')
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-
-        my_url = '/api/articles/user/search/?query=tags,author,title,description,body'
-        respo1 = client.put(
+        my_url = '/api/articles/author/search/?query=o'
+        respo1 = client.get(
             my_url,
-            test_data,
+            **self.header_user1,
             format='json',
         )
         self.assertEqual(respo1.status_code, status.HTTP_200_OK)
-        my_url = '/api/articles/user/search/?query=tags'
-        respo1 = client.put(
+        my_url = '/api/articles/title/search/?query=o'
+        respo1 = client.get(
             my_url,
-            test_data,
+            **self.header_user1,
             format='json',
         )
         self.assertEqual(respo1.status_code, status.HTTP_200_OK)
-        my_url = '/api/articles/user/search/?query=author'
-        respo1 = client.put(
+        my_url = '/api/articles/body/search/?query=o'
+        respo1 = client.get(
             my_url,
-            test_data,
+            **self.header_user1,
             format='json',
         )
         self.assertEqual(respo1.status_code, status.HTTP_200_OK)
-        my_url = '/api/articles/user/search/?query=title'
-        respo1 = client.put(
+        my_url = '/api/articles/tags/search/?query=o'
+        respo1 = client.get(
             my_url,
-            test_data,
+            **self.header_user1,
             format='json',
         )
         self.assertEqual(respo1.status_code, status.HTTP_200_OK)
-        my_url = '/api/articles/user/search/?query=description'
-        respo1 = client.put(
+        my_url = '/api/articles/description/search/?query=o'
+        respo1 = client.get(
             my_url,
-            test_data,
+            **self.header_user1,
             format='json',
         )
         self.assertEqual(respo1.status_code, status.HTTP_200_OK)
-        my_url = '/api/articles/user/search/?query=body'
-        respo1 = client.put(
+        my_url = '/api/articles/description/search/?query='
+        respo1 = client.get(
             my_url,
-            test_data,
+            **self.header_user1,
             format='json',
         )
-        self.assertEqual(respo1.status_code, status.HTTP_200_OK)
-
+        self.assertEqual(respo1.status_code, status.HTTP_400_BAD_REQUEST)

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -45,6 +45,6 @@ urlpatterns = [
          views.GetUserBookmarksView.as_view(), name="get_bookmarks"),
     path('<slug:slug>/report/',
          views.ReportAnArticle.as_view(), name="report-article"),
-    path('user/search/',
+    path('<slug:slug>/search/',
          views.SearchForArticles.as_view(), name="search-article"),
 ]


### PR DESCRIPTION
**Description**
<hr/>

This PR addresses the formatting of the search URL. Currently the search URL is implemented using a PUT method which is changed to a GET method in this PR. It also addresses the fact that searching for articles could yield a large number of articles hence the need to return results that are paginated to save on the lag time the application will take to load all the articles.  The endpoint also supports custom filtering with either `tags`, `author`, `title`, `description`, and `body` all supported as valid filters. This filters are applied as `slugs` in the search URL and the search string is entered as a parameter with the name of `query`. The search URL is as shown below:

`articles/<slug: slug>/search/?query=<search_value>`

For example `tags` would be: `articles/tags/search/?query=<search_value>` e.t.c


**Type of Change**
<hr/>

- [x] bug(a non-breaking change that allows users search for articles).

**Checklist**
<hr/>

- [x] Customising data representation in the search functionality.
- [x] Return paginated search results.
- [x] Add test to show search functionality operations.

**Related Stories**
<hr/>

[Fix search and custom filtering functionality](https://www.pivotaltracker.com/n/projects/2313280/stories/165963466)